### PR TITLE
Exchange custom netlink fork for neli crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ byte_conv = "0.1.1"
 hex = "^0.2"
 itertools = "^0.4"
 libc = "^0.2"
-neli = { git = "https://github.com/marcelbuesing/neli", branch = "master" }
+neli = "0.5.0-rc1"
 nix = "^0.5"
 try_from = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ byte_conv = "0.1.1"
 hex = "^0.2"
 itertools = "^0.4"
 libc = "^0.2"
-netlink-rs = { git = "https://github.com/mbr/netlink-rs", rev = "01cba6fcc7b11917890bc3d2b4635009fde8082c" }
+neli = { git = "https://github.com/marcelbuesing/neli", branch = "master" }
 nix = "^0.5"
 try_from = "0.2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ extern crate byte_conv;
 extern crate hex;
 extern crate itertools;
 extern crate libc;
-extern crate netlink_rs;
+extern crate neli;
 extern crate nix;
 extern crate try_from;
 


### PR DESCRIPTION
This removes the custom netlink dependency in exchange for the [neli](https://crates.io/crates/neli)-crate. I have tested `bring_up` and `bring_down` and it seems to work. There is a minor difference in the send that I have not figured out yet why sa_family is not added in neli or if that is even relevant since it has the intended effect.

`strace -s 100 -f -x ` of 

```Rust
    let iface = CanInterface::open("vcan0").expect("Failed to lookup vcan0 iface");
    iface.bring_down().unwrap();
```

netlink-rs fork:
```
bind(3, {sa_family=AF_NETLINK, nl_pid=29418, nl_groups=00000000}, 16) = 0
sendto(3, {{len=32, type=RTM_NEWLINK, flags=NLM_F_REQUEST|NLM_F_ACK, seq=0, pid=0}, {ifi_family=AF_UNSPEC, ifi_type=ARPHRD_NETROM, ifi_index=if_nametoindex("vcan0"), ifi_flags=0, ifi_change=0x1}}, 32, 0, {sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, 16) = 302
recvfrom(3, {{len=36, type=NLMSG_ERROR, flags=NLM_F_CAPPED, seq=0, pid=29418}, {error=0, msg={len=32, type=RTM_NEWLINK, flags=NLM_F_REQUEST|NLM_F_ACK, seq=0, pid=0}}}, 4096, 0, {sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, [16->12]) = 36
```

neli:
```
bind(3, {sa_family=AF_NETLINK, nl_pid=960, nl_groups=00000000}, 12) = 0
sendto(3, {{len=32, type=RTM_NEWLINK, flags=NLM_F_REQUEST|NLM_F_ACK, seq=0, pid=0}, {ifi_family=AF_UNSPEC, ifi_type=ARPHRD_NETROM, ifi_index=if_nametoindex("vcan0"), ifi_flags=0, ifi_change=0x1}}, 32, 0, NULL, 0) = 32
recvfrom(3, {{len=36, type=NLMSG_ERROR, flags=NLM_F_CAPPED, seq=0, pid=960}, {error=0, msg={len=32, type=RTM_NEWLINK, flags=NLM_F_REQUEST|NLM_F_ACK, seq=0, pid=0}}}, 32768, 0, NULL, NULL) = 36
```

WIP: since this is still waiting for merge of: https://github.com/jbaublitz/neli/pull/61, I will exchange the git link for a version once that is released.