### PR TITLE
Netlink extensions (issue #32)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ anyhow = "1.0"
 ctrlc = "3.2.2"
 clap = {version = "3.2.8", features = ["derive"]}
 nb = "1.0"
+serial_test = "0.9"
 
 [[bin]]
 name = "can"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ license = "MIT"
 [features]
 default = ["netlink"]
 netlink = ["neli"]
+root_tests = ["netlink"]
 vcan_tests = ["netlink"]
 utils = ["clap", "anyhow"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT"
 [features]
 default = ["netlink"]
 netlink = ["neli"]
-root_tests = ["netlink"]
+netlink_tests = ["netlink"]
 vcan_tests = ["netlink"]
 utils = ["clap", "anyhow"]
 

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -334,8 +334,11 @@ impl CanInterface {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
     use std::ops::Deref;
+
+    use serial_test::serial;
+
+    use super::*;
 
     /// RAII-style helper to create and clean-up a specific vcan interface for a single test.
     /// Using drop here ensures that the interface always gets cleaned up
@@ -382,6 +385,7 @@ pub mod tests {
 
     #[cfg(feature = "netlink_tests")]
     #[test]
+    #[serial]
     fn up_down() {
         let interface = TemporaryInterface::new("up_down").unwrap();
         assert!(interface.bring_up().is_ok());
@@ -392,6 +396,7 @@ pub mod tests {
 
     #[cfg(feature = "netlink_tests")]
     #[test]
+    #[serial]
     fn details() {
         let interface = TemporaryInterface::new("info").unwrap();
         let details = interface.details().unwrap();
@@ -402,6 +407,7 @@ pub mod tests {
 
     #[cfg(feature = "netlink_tests")]
     #[test]
+    #[serial]
     fn mtu() {
         let interface = TemporaryInterface::new("mtu").unwrap();
 

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -62,7 +62,7 @@ pub struct Details {
     pub mtu: Option<Mtu>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum Mtu {
     Standard = 16,
@@ -197,7 +197,7 @@ impl CanInterface {
                 buffer
             },
         );
-        let _ = Self::send_info_msg(Rtm::Newlink, info, &[NlmF::Create, NlmF::Excl])?;
+        Self::send_info_msg(Rtm::Newlink, info, &[NlmF::Create, NlmF::Excl])?;
 
         if let Ok(if_index) = if_nametoindex(name) {
             Ok(Self { if_index })

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -69,6 +69,28 @@ pub enum Mtu {
     Fd = 72,
 }
 
+// These are missing from libc and neli, adding them here as a stand-in for now.
+mod rt {
+    use libc::c_uint;
+
+    #[allow(unused)]
+    pub const EXT_FILTER_VF: c_uint = 1 << 0;
+    #[allow(unused)]
+    pub const EXT_FILTER_BRVLAN: c_uint = 1 << 1;
+    #[allow(unused)]
+    pub const EXT_FILTER_BRVLAN_COMPRESSED: c_uint = 1 << 2;
+    #[allow(unused)]
+    pub const EXT_FILTER_SKIP_STATS: c_uint = 1 << 3;
+    #[allow(unused)]
+    pub const EXT_FILTER_MRP: c_uint = 1 << 4;
+    #[allow(unused)]
+    pub const EXT_FILTER_CFM_CONFIG: c_uint = 1 << 5;
+    #[allow(unused)]
+    pub const EXT_FILTER_CFM_STATUS: c_uint = 1 << 6;
+    #[allow(unused)]
+    pub const EXT_FILTER_MST: c_uint = 1 << 7;
+}
+
 impl CanInterface {
     /// Open a CAN interface by name.
     ///
@@ -240,7 +262,7 @@ impl CanInterface {
             IffFlags::empty(),
             {
                 let mut buffer = RtBuffer::new();
-                buffer.push(Rtattr::new(None, Ifla::ExtMask, 1 as c_int).unwrap());
+                buffer.push(Rtattr::new(None, Ifla::ExtMask, rt::EXT_FILTER_VF).unwrap());
                 buffer
             },
         );
@@ -333,6 +355,7 @@ impl CanInterface {
 }
 
 #[cfg(test)]
+#[cfg(feature = "netlink_tests")]
 pub mod tests {
     use std::ops::Deref;
 

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -350,6 +350,7 @@ pub mod tests {
     }
 
     impl TemporaryInterface {
+        #[allow(unused)]
         pub fn new(name: &str) -> NlResult<Self> {
             Ok(Self {
                 interface: CanInterface::create_vcan(name)?,

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -70,7 +70,7 @@ pub enum Mtu {
 }
 
 impl CanInterface {
-    /// Open CAN interface by name
+    /// Open a CAN interface by name.
     ///
     /// Similar to `open_if`, but looks up the device by name instead
     pub fn open(ifname: &str) -> Result<Self, nix::Error> {
@@ -78,7 +78,7 @@ impl CanInterface {
         Ok(Self::open_iface(if_index))
     }
 
-    /// Open CAN interface
+    /// Open a CAN interface.
     ///
     /// Creates a new `CanInterface` instance. No actual "opening" is necessary
     /// or performed when calling this function.
@@ -88,7 +88,7 @@ impl CanInterface {
         }
     }
 
-    /// Sends an info message
+    /// Sends an info message.
     fn send_info_msg(msg_type: Rtm, info: Ifinfomsg, additional_flags: &[NlmF]) -> NlResult<()> {
         let mut nl = Self::open_route_socket()?;
 
@@ -132,8 +132,8 @@ impl CanInterface {
         }
     }
 
-    /// Opens a new netlink socket, bound to this process' PID
-    /// The function is generic allow for usage in contexts where NlError has specific,
+    /// Opens a new netlink socket, bound to this process' PID.
+    /// The function is generic to allow for usage in contexts where NlError has specific,
     /// non-default generic parameters.
     fn open_route_socket<T, P>() -> Result<NlSocketHandle, NlError<T, P>> {
         // retrieve PID
@@ -145,7 +145,7 @@ impl CanInterface {
         Ok(sock)
     }
 
-    /// Bring down CAN interface
+    /// Bring down this interface.
     ///
     /// Use a netlink control socket to set the interface status to "down".
     pub fn bring_down(&self) -> NlResult<()> {
@@ -171,13 +171,13 @@ impl CanInterface {
         Self::send_info_msg(Rtm::Newlink, info, &[])
     }
 
-    /// PRIVILEGED: Create a VCAN interface. Useful for testing applications.
+    /// PRIVILEGED: Attempt to create a VCAN interface. Useful for testing applications.
     /// Note that the length of the name is capped by ```libc::IFNAMSIZ```.
     pub fn create_vcan(name: &str, index: Option<u32>) -> NlResult<Self> {
         Self::create(name, index, "vcan")
     }
 
-    /// PRIVILEGED: Create a of the given kind.
+    /// PRIVILEGED: Create an interface of the given kind.
     /// Note that the length of the name is capped by ```libc::IFNAMSIZ```.
     pub fn create(name: &str, index: Option<u32>, kind: &str) -> NlResult<Self> {
         debug_assert!(name.len() <= libc::IFNAMSIZ);
@@ -310,7 +310,7 @@ impl CanInterface {
         }
     }
 
-    /// PRIVILEGED: Set the MTU of the given interface.
+    /// PRIVILEGED: Attempt to set the MTU of this interface.
     pub fn set_mtu(&self, mtu: Mtu) -> NlResult<()> {
         let info = Ifinfomsg::new(
             RtAddrFamily::Unspecified,
@@ -352,7 +352,7 @@ pub mod tests {
     ///     // use the interface..
     /// }
     /// ```
-    /// Please not that there is a limit to the length of interface names,
+    /// Please note that there is a limit to the length of interface names,
     /// namely 16 characters on Linux.
     pub struct TemporaryInterface {
         interface: CanInterface,
@@ -388,8 +388,10 @@ pub mod tests {
     #[serial]
     fn up_down() {
         let interface = TemporaryInterface::new("up_down").unwrap();
+
         assert!(interface.bring_up().is_ok());
         assert!(interface.details().unwrap().is_up);
+
         assert!(interface.bring_down().is_ok());
         assert!(!interface.details().unwrap().is_up);
     }

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -86,9 +86,12 @@ impl CanInterface {
         P: ToBytes + Debug,
     {
         sock.send(msg)?;
-        // TODO: Implement this
-        //sock.recv_ack()?;
-        Ok(())
+        // This will actually produce an Err if the response is a netlink error, no need to match.
+        if let NlPayload::Ack(_) = sock.recv()? {
+            Ok(())
+        } else {
+            Err(NlError::NoAck)
+        }
     }
 
     /// Opens a new netlink socket, bound to this process' PID


### PR DESCRIPTION
Hi everyone, 

this is a first step towards the requirements in #32. Specifically, it implements: 

- creating vcan (and theoretically other) CAN interfaces
- deleting interfaces
- reading rudimentary interface data (name, MTU, up/down) (can be extended easily by adding more entries in the corresponding loop)
- setting MTU (switching VCAN from FD to non-FD and vice versa) 

All of the tests added here need to be run as root and/or with CAP_NET_ADMIN capability. As such, I hid them behind another feature flag. They work locally for me. 

I did not get to bitrate and such because that actually does not work with vcan out-of-the-box; and I don't have a physical CAN device at home atm. 

For follow-up changes it might be interesting to know where I got the information from (which was quite painful as they documentation leaves some things to be desired..): 
- netlink and rnetlink documentation (https://man7.org/linux/man-pages/man7/netlink.7.html and https://man7.org/linux/man-pages/man7/rtnetlink.7.html)
- iproute2 (aka iptools) source: https://github.com/shemminger/iproute2
- ultimately, I mostly ended up just using ```strace``` with the ```ip link``` commands I was interested in 