### PR TITLE
Fix 1.7.0 security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Cargo.lock
+/target
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ itertools = "0.4"
 libc = "0.2"
 nix = "0.26"
 try_from = "0.2.0"
+static_assertions = "1.1.0"
 
 [features]
 vcan_tests = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,13 @@ documentation = "https://docs.rs/socketcan"
 license = "MIT"
 name = "socketcan"
 repository = "https://github.com/mbr/socketcan-rs"
-version = "1.7.0"
+version = "1.7.1"
 
 [dependencies]
-hex = "^0.2"
-itertools = "^0.4"
-libc = "^0.2"
-nix = "^0.5"
+hex = "0.2"
+itertools = "0.4"
+libc = "0.2"
+nix = "0.26"
 try_from = "0.2.0"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,11 @@ extern crate hex;
 extern crate itertools;
 extern crate libc;
 extern crate nix;
+extern crate static_assertions as sa;
 extern crate try_from;
+
+sa::assert_eq_size!(libc::can_frame, CANFrame);
+sa::const_assert_eq!(std::mem::size_of::<libc::can_frame>(), 16);
 
 mod err;
 pub use err::{CANError, CANErrorDecodingFailure};
@@ -376,6 +380,8 @@ impl CANSocket {
             let frame_ptr = &mut frame as *mut CANFrame;
             read(self.fd, frame_ptr as *mut c_void, size_of::<CANFrame>())
         };
+
+        assert!(frame._data_len <= 8);
 
         if read_rv as usize != size_of::<CANFrame>() {
             return Err(io::Error::last_os_error());


### PR DESCRIPTION
This PR addresses a high-severity vulnerability in the `nix` crate dependabot won't shut up about in everything downstream using the `1.7.0` version of the crate on crates.io.

This should merge against the v1.7.0 *tag* as base. Not sure what you want to do since the `1.7.0` branch seems to break semver (`CanFrame` is a trait, not a struct, and this won't suit my purposes).

There are three major changes in the PR:
* a `.gitignore` was added
* dependencies in `Cargo.toml` were un-pinned and the vulnerable nix crate was updated
* some compile-time size checks and one runtime length check was added to `lib.rs`. It's unlikely that the kernel would give a bad `can_dlc`, but I don't know it to be impossible. I haven't read all of the socketcan kernel source for every version of the kernel. If the `can_dlc` is not validated, it could result in an out of bounds read. The static size check is just for sanity so we can know libc's `can_frame` and our `CANFrame` are 16 bytes in size.