### PR TITLE
use OwnedFd and remove custom Drop implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,8 @@
     missing_debug_implementations,
     unstable_features,
     unused_import_braces,
-    unused_qualifications
+    unused_qualifications,
+    unsafe_op_in_unsafe_fn
 )]
 
 pub mod errors;


### PR DESCRIPTION
Quick change to use the newer OwnedFd/BorrowedFd API. This is stable since v1.63, so you might want to hold off on this if you are concerned about compatibility with earlier Rust versions.