### PR TITLE
add basic support for async-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ async-tokio = [ "tokio", "mio", "futures" ]
 netlink_tests = ["netlink"]
 vcan_tests = ["netlink"]
 utils = ["clap", "anyhow"]
+async-io = [ "dep:async-io" ]
 
 [dependencies]
 embedded-can = "0.4"
@@ -48,16 +49,19 @@ neli = { version = "0.6", optional = true }
 tokio = { version = "1", features = ["net"], optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 futures = { version = "0.3", optional = true }
-    
+async-io = { version = "1.13", optional = true }
+
 [dev-dependencies]
 anyhow = "1.0"
 ctrlc = "3.2.2"
 clap = { version = "4.0", features = ["derive"] }
 nb = "1.0"
-serial_test = "0.9"
 # TODO: Is it possible to only include these for async builds?
 futures-timer = "0.3"
 futures-util = "0.3"
+serial_test = { version = "2.0", features = ["async"]}
+async-std = { version = "1.12", features = ["attributes"]}
+futures = "0.3"
 
 [dev-dependencies.tokio]
 version = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,12 @@ pub mod dump;
 pub mod socket;
 pub use socket::{CanFdSocket, CanFilter, CanSocket, ShouldRetry, Socket};
 
+#[cfg(feature = "async-io")]
+/// Bindings to use with async-io based async runtimes, like async-std and smol.
+pub mod async_io {
+    pub use crate::socket::async_io::{CanFdSocket, CanSocket};
+}
+
 #[cfg(feature = "netlink")]
 mod nl;
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -37,6 +37,9 @@ pub use libc::{
     SOL_CAN_RAW,
 };
 
+#[cfg(feature = "async-io")]
+pub(crate) mod async_io;
+
 /// Check an error return value for timeouts.
 ///
 /// Due to the fact that timeouts are reported as errors, calling `read_frame`

--- a/src/socket/async_io.rs
+++ b/src/socket/async_io.rs
@@ -1,0 +1,182 @@
+// socketcan/src/socket/async_io.rs
+//
+// Implements sockets for CANbus 2.0 and FD for SocketCAN on Linux.
+//
+// This file is part of the Rust 'socketcan-rs' library.
+//
+// Licensed under the MIT license:
+//   <LICENSE or http://opensource.org/licenses/MIT>
+// This file may not be copied, modified, or distributed except according
+// to those terms.
+
+//! Bindings to async-io for CANbus 2.0 and FD sockets using SocketCAN on Linux.
+
+use std::mem::{size_of, MaybeUninit};
+use std::{
+    io, mem,
+    os::{raw::c_void, unix::io::AsRawFd},
+};
+
+use async_io::Async;
+use libc::{can_frame, canfd_frame, read, ssize_t, write};
+
+use crate::{frame::AsPtr, CanAnyFrame, CanFdFrame, CanFrame};
+
+macro_rules! write_frame {
+    ($target:expr, $frame_type:ty, $frame:expr) => {
+        $target
+            .write_with(|fd| {
+                let ret = unsafe {
+                    write(
+                        fd.as_raw_fd(),
+                        $frame.as_ptr() as *const c_void,
+                        <$frame_type>::size(),
+                    )
+                };
+                if ret == <$frame_type>::size() as isize {
+                    Ok(())
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            })
+            .await
+    };
+}
+
+// ===== CanSocket =====
+
+/// A socket for a classic CAN 2.0 device.
+///
+/// This provides an interface to read and write classic CAN 2.0 frames to
+/// the bus, with up to 8 bytes of data per frame. It wraps a Linux socket
+/// descriptor to a Raw SocketCAN socket.
+///
+/// The socket is automatically closed when the object is dropped. To close
+/// manually, use std::drop::Drop. Internally this is just a wrapped socket
+/// (file) descriptor.
+#[allow(missing_copy_implementations)]
+#[derive(Debug)]
+pub struct CanSocket {
+    inner: Async<super::CanSocket>,
+}
+
+impl TryFrom<super::CanSocket> for CanSocket {
+    type Error = io::Error;
+
+    fn try_from(value: super::CanSocket) -> Result<Self, Self::Error> {
+        Ok(Self {
+            inner: Async::new(value)?,
+        })
+    }
+}
+
+impl CanSocket {
+    /// Permits access to the inner synchronous socket, for example to perform settings.
+    pub fn as_sync_socket(&self) -> &super::CanSocket {
+        self.inner.as_ref()
+    }
+
+    /// Writes a standard 2.0 frame to the socket asynchronously.
+    pub async fn write_frame<F>(&self, frame: &F) -> io::Result<()>
+    where
+        F: Into<CanFrame> + AsPtr,
+    {
+        write_frame!(self.inner, F, frame)
+    }
+
+    /// Reads a standard 2.0 frame from the socket asynchronously.
+    pub async fn read_frame(&self) -> io::Result<CanFrame> {
+        let mut frame = MaybeUninit::<can_frame>::uninit();
+
+        self.inner
+            .read_with(|fd| {
+                let ret = unsafe {
+                    read(
+                        fd.as_raw_fd(),
+                        frame.as_mut_ptr() as *mut c_void,
+                        size_of::<can_frame>() as libc::size_t,
+                    )
+                };
+                if ret == size_of::<can_frame>() as isize {
+                    Ok(ret)
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            })
+            .await?;
+
+        //  SAFETY: Return value was okay and we trust the c library to have properly
+        //          filled the value.
+        let frame = unsafe { frame.assume_init() };
+        Ok(frame.into())
+    }
+}
+
+// ===== CanFdSocket =====
+
+/// A socket for CAN FD devices.
+///
+/// This can transmit and receive CAN 2.0 frames with up to 8-bytes of data,
+/// or CAN Flexible Data (FD) frames with up to 64-bytes of data.
+#[allow(missing_copy_implementations)]
+#[derive(Debug)]
+pub struct CanFdSocket {
+    /// The raw file descriptor
+    inner: Async<super::CanFdSocket>,
+}
+
+impl TryFrom<super::CanFdSocket> for CanFdSocket {
+    type Error = io::Error;
+
+    fn try_from(value: super::CanFdSocket) -> Result<Self, Self::Error> {
+        Ok(Self {
+            inner: Async::new(value)?,
+        })
+    }
+}
+
+impl CanFdSocket {
+    /// Permits access to the inner synchronous socket, for example to perform settings.
+    pub fn as_sync_socket(&self) -> &super::CanFdSocket {
+        self.inner.as_ref()
+    }
+
+    /// Writes either a standard 2.0 frame or an FD frame to the socket asynchronously.
+    pub async fn write_frame<F>(&self, frame: &F) -> io::Result<()>
+    where
+        F: Into<CanAnyFrame> + AsPtr,
+    {
+        write_frame!(self.inner, F, frame)
+    }
+
+    /// Reads either a standard 2.0 frame or an FD frame from the socket asynchronously.
+    pub async fn read_frame(&self) -> io::Result<CanAnyFrame> {
+        let mut frame = MaybeUninit::<canfd_frame>::uninit();
+
+        self.inner
+            .read_with(|fd| {
+                let ret = unsafe {
+                    read(
+                        fd.as_raw_fd(),
+                        frame.as_mut_ptr() as *mut c_void,
+                        size_of::<canfd_frame>() as libc::size_t,
+                    )
+                };
+
+                if ret == size_of::<can_frame>() as ssize_t {
+                    // SAFETY: We are assuming that the C standard library upholds its contract
+                    //         and writes a valid can_frame into the buffer.
+                    let frame = unsafe { mem::transmute_copy::<_, can_frame>(&frame) };
+                    Ok(<can_frame as Into<CanFrame>>::into(frame).into())
+                } else if ret == size_of::<canfd_frame>() as ssize_t {
+                    // SAFETY: We are assuming that the C standard library upholds its contract
+                    //         and writes a valid canfd_frame into the buffer.
+                    let frame = unsafe { frame.assume_init() };
+                    Ok(<canfd_frame as Into<CanFdFrame>>::into(frame).into())
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            })
+            .await
+    }
+}

--- a/src/socket/async_io.rs
+++ b/src/socket/async_io.rs
@@ -11,188 +11,65 @@
 
 //! Bindings to async-io for CANbus 2.0 and FD sockets using SocketCAN on Linux.
 
-use std::mem::{size_of, MaybeUninit};
-use std::{
-    io, mem,
-    os::{raw::c_void, unix::io::AsRawFd},
-};
+use std::io;
 
 use async_io::Async;
-use libc::{can_frame, canfd_frame, read, ssize_t, write};
 
-use crate::{frame::AsPtr, CanAnyFrame, CanFdFrame, CanFrame, Socket};
+use crate::{frame::AsPtr, CanAnyFrame, CanFrame, Socket};
 
-macro_rules! write_frame {
-    ($target:expr, $frame_type:ty, $frame:expr) => {
-        $target
-            .write_with(|fd| {
-                let ret = unsafe {
-                    write(
-                        fd.as_raw_fd(),
-                        $frame.as_ptr() as *const c_void,
-                        <$frame_type>::size(),
-                    )
-                };
-                if ret == <$frame_type>::size() as isize {
-                    Ok(())
-                } else {
-                    Err(io::Error::last_os_error())
-                }
-            })
-            .await
+macro_rules! create_async_socket {
+    ($target_type:ident, $wrapped_type:ty, $frame_type:ty) => {
+        #[doc = concat!("Async version of ", stringify!($wrapped_type),". See the original type's documentation for details.")]
+        #[allow(missing_copy_implementations)]
+        #[derive(Debug)]
+        pub struct $target_type {
+            inner: Async<$wrapped_type>,
+        }
+
+        impl TryFrom<$wrapped_type> for $target_type {
+            type Error = io::Error;
+
+            fn try_from(value: $wrapped_type) -> Result<Self, Self::Error> {
+                Ok(Self {
+                    inner: Async::new(value)?,
+                })
+            }
+        }
+
+        impl $target_type {
+            /// Open a named CAN device.
+            ///
+            /// Usually the more common case, opens a socket can device by name, such
+            /// as "can0", "vcan0", or "socan0".
+            pub fn open(ifname: &str) -> io::Result<Self> {
+                <$wrapped_type>::open(ifname)?.try_into()
+            }
+
+            /// Permits access to the inner synchronous socket, for example to change options.
+            pub fn blocking(&self) -> &$wrapped_type {
+                self.inner.as_ref()
+            }
+
+            /// Permits mutable access to the inner synchronous socket, for example to change options.
+            pub fn blocking_mut(&mut self) -> &mut $wrapped_type {
+                self.inner.as_mut()
+            }
+
+            /// Writes a frame to the socket asynchronously.
+            pub async fn write_frame<F>(&self, frame: &F) -> io::Result<()>
+            where
+                F: Into<$frame_type> + AsPtr,
+            {
+                self.inner.write_with(|fd| fd.write_frame(frame)).await
+            }
+
+            /// Reads a frame from the socket asynchronously.
+            pub async fn read_frame(&self) -> io::Result<$frame_type> {
+                self.inner.read_with(|fd| fd.read_frame()).await
+            }
+        }
     };
 }
 
-// ===== CanSocket =====
-
-/// A socket for a classic CAN 2.0 device.
-///
-/// This provides an interface to read and write classic CAN 2.0 frames to
-/// the bus, with up to 8 bytes of data per frame. It wraps a Linux socket
-/// descriptor to a Raw SocketCAN socket.
-///
-/// The socket is automatically closed when the object is dropped. To close
-/// manually, use std::drop::Drop. Internally this is just a wrapped socket
-/// (file) descriptor.
-#[allow(missing_copy_implementations)]
-#[derive(Debug)]
-pub struct CanSocket {
-    inner: Async<super::CanSocket>,
-}
-
-impl TryFrom<super::CanSocket> for CanSocket {
-    type Error = io::Error;
-
-    fn try_from(value: super::CanSocket) -> Result<Self, Self::Error> {
-        Ok(Self {
-            inner: Async::new(value)?,
-        })
-    }
-}
-
-impl CanSocket {
-    /// Open a named CAN device.
-    ///
-    /// Usually the more common case, opens a socket can device by name, such
-    /// as "can0", "vcan0", or "socan0".
-    pub fn open(ifname: &str) -> io::Result<Self> {
-        super::CanSocket::open(ifname)?.try_into()
-    }
-
-    /// Permits access to the inner synchronous socket, for example to perform settings.
-    pub fn as_sync_socket(&self) -> &super::CanSocket {
-        self.inner.as_ref()
-    }
-
-    /// Writes a standard 2.0 frame to the socket asynchronously.
-    pub async fn write_frame<F>(&self, frame: &F) -> io::Result<()>
-    where
-        F: Into<CanFrame> + AsPtr,
-    {
-        write_frame!(self.inner, F, frame)
-    }
-
-    /// Reads a standard 2.0 frame from the socket asynchronously.
-    pub async fn read_frame(&self) -> io::Result<CanFrame> {
-        let mut frame = MaybeUninit::<can_frame>::uninit();
-
-        self.inner
-            .read_with(|fd| {
-                let ret = unsafe {
-                    read(
-                        fd.as_raw_fd(),
-                        frame.as_mut_ptr() as *mut c_void,
-                        size_of::<can_frame>() as libc::size_t,
-                    )
-                };
-                if ret == size_of::<can_frame>() as isize {
-                    Ok(ret)
-                } else {
-                    Err(io::Error::last_os_error())
-                }
-            })
-            .await?;
-
-        //  SAFETY: Return value was okay and we trust the c library to have properly
-        //          filled the value.
-        let frame = unsafe { frame.assume_init() };
-        Ok(frame.into())
-    }
-}
-
-// ===== CanFdSocket =====
-
-/// A socket for CAN FD devices.
-///
-/// This can transmit and receive CAN 2.0 frames with up to 8-bytes of data,
-/// or CAN Flexible Data (FD) frames with up to 64-bytes of data.
-#[allow(missing_copy_implementations)]
-#[derive(Debug)]
-pub struct CanFdSocket {
-    /// The raw file descriptor
-    inner: Async<super::CanFdSocket>,
-}
-
-impl TryFrom<super::CanFdSocket> for CanFdSocket {
-    type Error = io::Error;
-
-    fn try_from(value: super::CanFdSocket) -> Result<Self, Self::Error> {
-        Ok(Self {
-            inner: Async::new(value)?,
-        })
-    }
-}
-
-impl CanFdSocket {
-    /// Open a named CAN device.
-    ///
-    /// Usually the more common case, opens a socket can device by name, such
-    /// as "can0", "vcan0", or "socan0".
-    pub fn open(ifname: &str) -> io::Result<Self> {
-        super::CanFdSocket::open(ifname)?.try_into()
-    }
-
-    /// Permits access to the inner synchronous socket, for example to perform settings.
-    pub fn as_sync_socket(&self) -> &super::CanFdSocket {
-        self.inner.as_ref()
-    }
-
-    /// Writes either a standard 2.0 frame or an FD frame to the socket asynchronously.
-    pub async fn write_frame<F>(&self, frame: &F) -> io::Result<()>
-    where
-        F: Into<CanAnyFrame> + AsPtr,
-    {
-        write_frame!(self.inner, F, frame)
-    }
-
-    /// Reads either a standard 2.0 frame or an FD frame from the socket asynchronously.
-    pub async fn read_frame(&self) -> io::Result<CanAnyFrame> {
-        let mut frame = MaybeUninit::<canfd_frame>::uninit();
-
-        self.inner
-            .read_with(|fd| {
-                let ret = unsafe {
-                    read(
-                        fd.as_raw_fd(),
-                        frame.as_mut_ptr() as *mut c_void,
-                        size_of::<canfd_frame>() as libc::size_t,
-                    )
-                };
-
-                if ret == size_of::<can_frame>() as ssize_t {
-                    // SAFETY: We are assuming that the C standard library upholds its contract
-                    //         and writes a valid can_frame into the buffer.
-                    let frame = unsafe { mem::transmute_copy::<_, can_frame>(&frame) };
-                    Ok(<can_frame as Into<CanFrame>>::into(frame).into())
-                } else if ret == size_of::<canfd_frame>() as ssize_t {
-                    // SAFETY: We are assuming that the C standard library upholds its contract
-                    //         and writes a valid canfd_frame into the buffer.
-                    let frame = unsafe { frame.assume_init() };
-                    Ok(<canfd_frame as Into<CanFdFrame>>::into(frame).into())
-                } else {
-                    Err(io::Error::last_os_error())
-                }
-            })
-            .await
-    }
-}
+create_async_socket!(CanSocket, super::CanSocket, CanFrame);
+create_async_socket!(CanFdSocket, super::CanFdSocket, CanAnyFrame);

--- a/src/socket/async_io.rs
+++ b/src/socket/async_io.rs
@@ -20,7 +20,7 @@ use std::{
 use async_io::Async;
 use libc::{can_frame, canfd_frame, read, ssize_t, write};
 
-use crate::{frame::AsPtr, CanAnyFrame, CanFdFrame, CanFrame};
+use crate::{frame::AsPtr, CanAnyFrame, CanFdFrame, CanFrame, Socket};
 
 macro_rules! write_frame {
     ($target:expr, $frame_type:ty, $frame:expr) => {
@@ -71,6 +71,14 @@ impl TryFrom<super::CanSocket> for CanSocket {
 }
 
 impl CanSocket {
+    /// Open a named CAN device.
+    ///
+    /// Usually the more common case, opens a socket can device by name, such
+    /// as "can0", "vcan0", or "socan0".
+    pub fn open(ifname: &str) -> io::Result<Self> {
+        super::CanSocket::open(ifname)?.try_into()
+    }
+
     /// Permits access to the inner synchronous socket, for example to perform settings.
     pub fn as_sync_socket(&self) -> &super::CanSocket {
         self.inner.as_ref()
@@ -136,6 +144,14 @@ impl TryFrom<super::CanFdSocket> for CanFdSocket {
 }
 
 impl CanFdSocket {
+    /// Open a named CAN device.
+    ///
+    /// Usually the more common case, opens a socket can device by name, such
+    /// as "can0", "vcan0", or "socan0".
+    pub fn open(ifname: &str) -> io::Result<Self> {
+        super::CanFdSocket::open(ifname)?.try_into()
+    }
+
     /// Permits access to the inner synchronous socket, for example to perform settings.
     pub fn as_sync_socket(&self) -> &super::CanFdSocket {
         self.inner.as_ref()

--- a/tests/cansocket-asyncio.rs
+++ b/tests/cansocket-asyncio.rs
@@ -1,0 +1,71 @@
+// socketcan/tests/cansocket.rs
+//
+// Integration tests for CAN sockets.
+//
+// This file is part of the Rust 'socketcan-rs' library.
+//
+// Licensed under the MIT license:
+//   <LICENSE or http://opensource.org/licenses/MIT>
+// This file may not be copied, modified, or distributed except according
+// to those terms.
+
+#[cfg(all(feature = "vcan_tests", feature = "async-io"))]
+use serial_test::serial;
+
+#[cfg(all(feature = "vcan_tests", feature = "async-io"))]
+use socketcan::{
+    async_io::CanFdSocket as AsyncCanFdSocket, async_io::CanSocket as AsyncCanSocket,
+    frame::FdFlags, CanAnyFrame, CanFdFrame, CanFdSocket, EmbeddedFrame, Id, Socket, StandardId,
+};
+
+// The virtual CAN interface to use for tests.
+#[cfg(all(feature = "vcan_tests", feature = "async-io"))]
+const VCAN: &str = "vcan0";
+
+#[cfg(all(feature = "vcan_tests", feature = "async-io"))]
+#[serial]
+#[async_std::test]
+async fn async_can_simple() {
+    let writer: AsyncCanSocket = socketcan::CanSocket::open(VCAN)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let reader: AsyncCanSocket = socketcan::CanSocket::open(VCAN)
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let frame =
+        socketcan::CanFrame::new(Id::from(StandardId::new(0x14).unwrap()), &[1, 3, 3, 7]).unwrap();
+
+    let (write_result, read_result) =
+        futures::join!(writer.write_frame(&frame), reader.read_frame());
+
+    assert!(write_result.is_ok());
+    assert_eq!(frame.data(), read_result.unwrap().data());
+}
+
+#[cfg(all(feature = "vcan_tests", feature = "async-io"))]
+#[serial]
+#[async_std::test]
+async fn async_canfd_simple() {
+    let writer: AsyncCanFdSocket = CanFdSocket::open(VCAN).unwrap().try_into().unwrap();
+    let reader: AsyncCanFdSocket = CanFdSocket::open(VCAN).unwrap().try_into().unwrap();
+
+    let frame = CanFdFrame::with_flags(
+        StandardId::new(111).unwrap(),
+        // Note: OS may report this frame as a normal CAN frame if it is 8 or less bytes of payload..
+        &[1, 3, 3, 7, 1, 2, 3, 4, 5],
+        FdFlags::empty(),
+    )
+    .unwrap();
+
+    let (write_result, read_result) =
+        futures::join!(writer.write_frame(&frame), reader.read_frame());
+
+    assert!(write_result.is_ok());
+    match read_result.unwrap() {
+        CanAnyFrame::Fd(read_frame) => assert_eq!(read_frame.data(), frame.data()),
+        _ => panic!("Did not get FD frame back!"),
+    }
+}

--- a/tests/cansocket-asyncio.rs
+++ b/tests/cansocket-asyncio.rs
@@ -15,7 +15,7 @@ use serial_test::serial;
 #[cfg(all(feature = "vcan_tests", feature = "async-io"))]
 use socketcan::{
     async_io::CanFdSocket as AsyncCanFdSocket, async_io::CanSocket as AsyncCanSocket,
-    frame::FdFlags, CanAnyFrame, CanFdFrame, CanFdSocket, EmbeddedFrame, Id, Socket, StandardId,
+    frame::FdFlags, CanAnyFrame, CanFdFrame, EmbeddedFrame, Id, StandardId,
 };
 
 // The virtual CAN interface to use for tests.
@@ -26,14 +26,8 @@ const VCAN: &str = "vcan0";
 #[serial]
 #[async_std::test]
 async fn async_can_simple() {
-    let writer: AsyncCanSocket = socketcan::CanSocket::open(VCAN)
-        .unwrap()
-        .try_into()
-        .unwrap();
-    let reader: AsyncCanSocket = socketcan::CanSocket::open(VCAN)
-        .unwrap()
-        .try_into()
-        .unwrap();
+    let writer = AsyncCanSocket::open(VCAN).unwrap();
+    let reader = AsyncCanSocket::open(VCAN).unwrap();
 
     let frame =
         socketcan::CanFrame::new(Id::from(StandardId::new(0x14).unwrap()), &[1, 3, 3, 7]).unwrap();
@@ -49,8 +43,8 @@ async fn async_can_simple() {
 #[serial]
 #[async_std::test]
 async fn async_canfd_simple() {
-    let writer: AsyncCanFdSocket = CanFdSocket::open(VCAN).unwrap().try_into().unwrap();
-    let reader: AsyncCanFdSocket = CanFdSocket::open(VCAN).unwrap().try_into().unwrap();
+    let writer = AsyncCanFdSocket::open(VCAN).unwrap();
+    let reader = AsyncCanFdSocket::open(VCAN).unwrap();
 
     let frame = CanFdFrame::with_flags(
         StandardId::new(111).unwrap(),


### PR DESCRIPTION
As discussed in #39, this adds basic support for async-io based async runtimes like async-std and smol. Couple of notes: 

- ~~I did not add a direct constructor, instead relying on TryFrom<CanSocket/CanFdSocket>. This could be added easily though.~~
- I did not add a method to get back to the synchronous socket, partially because I haven't figured out how to do that yet. 
- I pretty much only ported the read and write functionality, since setting socket options is not possible asynchronously on Linux. To maintain access to the different setup methods, I give access to the inner socket via `as_sync_socket` methods. 
- ~~Instead of using the mem::zeroed-based approach when reading, I actually went with the MaybeUninit strategy, which I believe to be sound. However, I can go back to the zeroed version used for the synchronous read operations.~~ Now just using the synchronous methods. 

Thanks for any feedback! 