### PR TITLE
feat: Add CanFdSocket support for tokio module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Cargo.lock
 /.hgignore
 /.vscode
 /socketcan.v*
+/.envrc
+/.direnv

--- a/README.md
+++ b/README.md
@@ -134,3 +134,12 @@ The steps to install and add a virtual interface to Linux are in the `scripts/vc
 $ sudo ./scripts/vcan.sh
 $ cargo test --features=vcan_tests
 ```
+
+### Developing with Nix
+
+If you have [Nix](https://nixos.org/) installed, you can enter a development that includes the needed rust dependencies with
+```bash
+nix develop
+```
+
+> Notes: You must have a version of nix that supports flakes.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ cargo test --features=vcan_tests
 
 ### Developing with Nix
 
-If you have [Nix](https://nixos.org/) installed, you can enter a development that includes the needed rust dependencies with
+If you have [Nix](https://nixos.org/) installed, you can enter a development shell that includes the needed rust dependencies with
 ```bash
 nix develop
 ```

--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ If you have [Nix](https://nixos.org/) installed, you can enter a development she
 nix develop
 ```
 
-> Notes: You must have a version of nix that supports flakes.
+> Note: You must have a version of nix that supports flakes.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697059129,
+        "narHash": "sha256-9NJcFF9CEYPvHJ5ckE8kvINvI84SZZ87PvqMbH6pro0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5e4c2ada4fcd54b99d56d7bd62f384511a7e2593",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1697508761,
+        "narHash": "sha256-QKWiXUlnke+EiJw3pek1l7xyJ4YsxYXZeQJt/YLgjvA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6f74c92caaf2541641b50ec623676430101d1fd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
         {
           devShells.default = mkShell {
             buildInputs = [ rust-bin.stable.latest.default ];
+            shellHook = ''PS1="\n\[\033[01;32m\]\u $\[\033[00m\]\[\033[01;36m\] \w >\[\033[00m\]\n"'';
           };
           formatter = pkgs.nixpkgs-fmt;
         }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+        in
+        with pkgs;
+        {
+          devShells.default = mkShell {
+            buildInputs = [ rust-bin.stable.latest.default ];
+          };
+          formatter = pkgs.nixpkgs-fmt;
+        }
+      );
+}

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -209,7 +209,7 @@ impl Sink<CanFrame> for CanSocket {
 
 /// A Future representing the eventual writing of a CanFdFrame to the socket.
 ///
-/// Created by the CanSocket.write_frame() method
+/// Created by the CanFdSocket.write_frame() method
 #[derive(Debug)]
 pub struct CanFdWriteFuture {
     socket: CanFdSocket,

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -207,7 +207,7 @@ impl Sink<CanFrame> for CanSocket {
     }
 }
 
-/// A Future representing the eventual writing of a CanFrame to the socket.
+/// A Future representing the eventual writing of a CanFdFrame to the socket.
 ///
 /// Created by the CanSocket.write_frame() method
 #[derive(Debug)]
@@ -284,7 +284,7 @@ impl CanFdSocket {
         Ok(Self(AsyncFd::new(EventedCanFdSocket(sock))?))
     }
 
-    /// Write a CAN frame to the socket asynchronously
+    /// Write a CANFd frame to the socket asynchronously
     ///
     /// This uses the semantics of socketcan's `write_frame_insist`,
     /// IE: it will automatically retry when it fails on an EINTR


### PR DESCRIPTION
This PR adds CanFdSocket support for the tokio async module. The implementation is the same as for the regular CanSocket. 

A flake.nix file was also added to enable development with [nix](https://nixos.org/) (the package manager). 