### PR TITLE
Make CanState public

### DIFF
--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -78,7 +78,8 @@ use std::{
 /// Low-level Netlink CAN struct bindings.
 mod rt;
 
-use rt::{can_ctrlmode, CanState};
+use rt::can_ctrlmode;
+pub use rt::CanState;
 
 /// A result for Netlink errors.
 type NlResult<T> = Result<T, NlError>;

--- a/src/nl/rt.rs
+++ b/src/nl/rt.rs
@@ -111,12 +111,18 @@ pub struct can_clock {
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CanState {
-    ErrorActive,  // RX/TX error count < 96
-    ErrorWarning, // RX/TX error count < 128
-    ErrorPassive, // RX/TX error count < 256
-    BusOff,       // RX/TX error count >= 256
-    Stopped,      // Device is stopped
-    Sleeping,     // Device is sleeping
+    /// RX/TX error count < 96
+    ErrorActive,
+    /// RX/TX error count < 128
+    ErrorWarning,
+    /// RX/TX error count < 256
+    ErrorPassive,
+    /// RX/TX error count >= 256
+    BusOff,
+    /// Device is stopped
+    Stopped,
+    /// Device is sleeping
+    Sleeping,
 }
 
 impl TryFrom<u32> for CanState {


### PR DESCRIPTION
This change enables pattern matching of `enum CanState` from client code by marking it as `pub`.
I've also restructured comments so that compiler doesn't complain about missing docs.

Let me know if you think this change requires more thought.