### PR TITLE
`CanFdSocket` read_frame crash fix

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -614,7 +614,7 @@ impl CanFdSocket {
             // proper type.
             CAN_MTU => {
                 let mut frame = can_frame_default();
-                as_bytes_mut(&mut frame)[..CAN_MTU].copy_from_slice(as_bytes(&fdframe));
+                as_bytes_mut(&mut frame)[..CAN_MTU].copy_from_slice(&as_bytes(&fdframe)[..CAN_MTU]);
                 Ok(frame.into())
             }
             CANFD_MTU => Ok(fdframe.into()),

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -662,7 +662,7 @@ impl Socket for CanFdSocket {
             // proper type.
             CAN_MTU => {
                 let mut frame = can_frame_default();
-                as_bytes_mut(&mut frame)[..CAN_MTU].copy_from_slice(as_bytes(&fdframe));
+                as_bytes_mut(&mut frame)[..CAN_MTU].copy_from_slice(&as_bytes(&fdframe)[..CAN_MTU]);
                 Ok(CanFrame::from(frame).into())
             }
             CANFD_MTU => Ok(CanFdFrame::from(fdframe).into()),


### PR DESCRIPTION
Reading a standard CAN frame through the `CanFdSocket` leads to a crash due to mismatching sizes in the frame construction’s `copy_from_slice`. Thix fix has been tested and builds valid CAN frames.