### PR TITLE
Add Socket::recv_with_meta to read loopback status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ Linux SocketCAN library. Send and receive CAN frames via CANbus on Linux.
 
 # Features:
 #
-# "netlink" (default) - Whether to include CAN interface configuration 
+# "netlink" (default) - Whether to include CAN interface configuration
 #       capabilities based on netlink kernel communications
-# "dump" (default) - Whether to include 'candump' output parsing 
+# "dump" (default) - Whether to include 'candump' output parsing
 #	capabilities.
 # "utils" - Build the command-line utilities
 #
@@ -44,7 +44,7 @@ libc = "0.2"
 nix = "0.26"
 bitflags = "1.3"
 thiserror = "1.0"
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { git = "https://github.com/rust-lang/socket2.git", features = ["all"] }
 clap = { version = "4.2", optional = true }
 anyhow = { version = "1.0", optional = true }
 neli = { version = "0.6", optional = true }
@@ -111,4 +111,3 @@ required-features = ["async-std"]
 [[example]]
 name = "async_std_print_frames"
 required-features = ["async-std"]
-

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -249,6 +249,14 @@ impl From<canfd_frame> for CanRawFrame {
     }
 }
 
+
+/// Frame metadata
+#[derive(Clone, Copy, Debug)]
+pub struct CanFrameMetaData {
+    /// Indicates the frame was sent out by the same socket
+    pub loopback: bool,
+}
+
 /// Any frame type.
 #[derive(Clone, Copy, Debug)]
 pub enum CanAnyFrame {


### PR DESCRIPTION
Wanted to check the transmission confirmation flag (e.g. the `MSG_CONFIRM` flag). This required quite a bit of changes, but they might be a nice first step towards getting the timestamps (https://github.com/socketcan-rs/socketcan-rs/issues/22).

Open questions:
 - Do you agree with the implementation, and think this makes sense? I tried to follow the logic of the commented out `read_frame_with_timestamp`.
 - I'm a bit unsure about the usage of `socket2::MaybeUninitSlice`. Can we implement this without needing unsafe code?
 - Do you want two separate implementations for `read_frame` (`read()`) and `read_frame_with_meta` (`recvmsg()`)? `read_frame` can also call `read_frame_with_meta` and throw away the metadata. It seems like there is also quite a bit of duplication between `CanSocket` and `CanFdSocket`.