### PR TITLE
Make termination u16 and add set_termination

### DIFF
--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -827,8 +827,8 @@ impl CanInterface {
     }
 
     /// Gets the CANbus termination for the interface
-    pub fn termination(&self) -> Result<Option<u32>, NlInfoError> {
-        self.can_param::<u32>(IflaCan::Termination)
+    pub fn termination(&self) -> Result<Option<u16>, NlInfoError> {
+        self.can_param::<u16>(IflaCan::Termination)
     }
 }
 

--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -826,6 +826,18 @@ impl CanInterface {
         self.can_param::<CanBitTimingConst>(IflaCan::DataBitTimingConst)
     }
 
+    /// Sets the CANbus termination for the interface
+    ///
+    /// Not all interfaces support setting a termination.
+    /// Termination is in ohms. Your interface most likely only supports
+    /// certain values. Common values are 0 and 120.
+    ///
+    /// PRIVILEGED: This requires root privilege.
+    ///
+    pub fn set_termination(&self, termination: u16) -> NlResult<()> {
+        self.set_can_param(IflaCan::Termination, termination)
+    }
+
     /// Gets the CANbus termination for the interface
     pub fn termination(&self) -> Result<Option<u16>, NlInfoError> {
         self.can_param::<u16>(IflaCan::Termination)


### PR DESCRIPTION
This fixes `termination` in the user facing api to be an `u16` like it is in the kernel and then adds a set_termination function to set the internal termination resistor, for can interfaces that support it.