### PR TITLE
Dump parsing also optionally trims off CR at the line end

### DIFF
--- a/src/dump.rs
+++ b/src/dump.rs
@@ -181,6 +181,10 @@ impl<R: io::BufRead> Reader<R> {
         if let Some(&b'\n') = can_data.last() {
             can_data = &can_data[..can_data.len() - 1];
         };
+        // cut off \r
+        if let Some(&b'\r') = can_data.last() {
+            can_data = &can_data[..can_data.len() - 1];
+        };
 
         let mut flags = IdFlags::empty();
         flags.set(IdFlags::RTR, b"R" == can_data);


### PR DESCRIPTION
Would you be open to merging this?

I haven't looked into _why_ my candump has a \r\n rather than just a \n at the line ending but it does.