### PR TITLE
CanInterface: add set_can_params method to set multiple parameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub use socket::{CanFdSocket, CanFilter, CanSocket, ShouldRetry, Socket, SocketO
 pub mod nl;
 
 #[cfg(feature = "netlink")]
-pub use nl::{CanCtrlMode, CanInterface};
+pub use nl::{CanCtrlMode, CanInterface, SetCanParams};
 
 /// Optional tokio support
 #[cfg(feature = "tokio")]


### PR DESCRIPTION
This new method allows to set multiple CAN-specific parameters at once instead of over multiple netlink messages.

This is also required for some more obscure devices which might not accept some parameter configurations split over multiple netlink messages.