### PR TITLE
Improved tokio async implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ futures-timer = "0.3"
 futures-util = "0.3"
 serial_test = { version = "2.0", features = ["async"]}
 async-std = { version = "1.12", features = ["attributes"]}
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util"] }
 futures = "0.3"
 
 

--- a/examples/tokio_average.rs
+++ b/examples/tokio_average.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
             frame.set_id(StandardId::new(0x101).unwrap());
             frame.set_data(&avg.to_le_bytes()).unwrap();
 
-            sock_tx.write_frame(frame)?.await?;
+            sock_tx.write_frame(frame).await?;
         }
 
         Ok::<(), Error>(())

--- a/examples/tokio_bridge.rs
+++ b/examples/tokio_bridge.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
 
     while let Some(Ok(frame)) = sock_rx.next().await {
         if matches!(frame, CanFrame::Data(_)) {
-            sock_tx.write_frame(frame)?.await?;
+            sock_tx.write_frame(frame).await?;
         }
     }
 

--- a/examples/tokio_send.rs
+++ b/examples/tokio_send.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
         let frame = CanFrame::new(id, &[0]).unwrap();
 
         println!("Writing on vcan0");
-        socket_tx.write_frame(frame)?.await?;
+        socket_tx.write_frame(frame).await?;
 
         println!("Waiting 3 seconds");
         Delay::new(Duration::from_secs(3)).await?;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -698,6 +698,22 @@ impl AsFd for CanFdSocket {
     }
 }
 
+impl Read for CanFdSocket {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Write for CanFdSocket {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        self.0.flush()
+    }
+}
+
 // ===== CanFilter =====
 
 /// The CAN filter defines which ID's can be accepted on a socket.

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -21,7 +21,7 @@
 //!     let socket_tx = CanSocket::open("vcan0")?;
 //!
 //!     while let Some(Ok(frame)) = socket_rx.next().await {
-//!         socket_tx.write_frame(frame)?.await;
+//!         socket_tx.write_frame(frame).await;
 //!     }
 //!     Ok(())
 //! }
@@ -30,117 +30,41 @@ use crate::{
     CanAddr, CanAnyFrame, CanFdFrame, CanFrame, Error, IoResult, Result, Socket, SocketOptions,
 };
 use futures::{prelude::*, ready, task::Context};
-use mio::{event, unix::SourceFd, Interest, Registry, Token};
 use std::{
-    future::Future,
     os::unix::{
-        io::{AsRawFd, FromRawFd, OwnedFd},
+        io::{AsRawFd, OwnedFd},
         prelude::RawFd,
     },
     pin::Pin,
     task::Poll,
 };
 use tokio::io::unix::AsyncFd;
-
-/// A Future representing the eventual writing of a CanFrame to the socket.
-///
-/// Created by the CanSocket.write_frame() method
-#[derive(Debug)]
-pub struct CanWriteFuture {
-    socket: CanSocket,
-    frame: CanFrame,
-}
-
-impl Future for CanWriteFuture {
-    type Output = IoResult<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let _ = ready!(self.socket.0.poll_write_ready(cx))?;
-        match self.socket.0.get_ref().0.write_frame_insist(&self.frame) {
-            Ok(_) => Poll::Ready(Ok(())),
-            Err(err) => Poll::Ready(Err(err)),
-        }
-    }
-}
-
-/// A CanSocket wrapped for mio eventing
-/// to allow it be integrated in turn into tokio
-#[derive(Debug)]
-pub struct EventedCanSocket<T: Socket = crate::CanSocket>(T);
-
-impl<T: Socket> EventedCanSocket<T> {
-    fn get_ref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T: Socket> AsRawFd for EventedCanSocket<T> {
-    fn as_raw_fd(&self) -> RawFd {
-        self.0.as_raw_fd()
-    }
-}
-
-impl<T: Socket> event::Source for EventedCanSocket<T> {
-    fn register(&mut self, registry: &Registry, token: Token, interests: Interest) -> IoResult<()> {
-        SourceFd(&self.0.as_raw_fd()).register(registry, token, interests)
-    }
-
-    fn reregister(
-        &mut self,
-        registry: &Registry,
-        token: Token,
-        interests: Interest,
-    ) -> IoResult<()> {
-        SourceFd(&self.0.as_raw_fd()).reregister(registry, token, interests)
-    }
-
-    fn deregister(&mut self, registry: &Registry) -> IoResult<()> {
-        SourceFd(&self.0.as_raw_fd()).deregister(registry)
-    }
-}
+use tokio::io::Interest;
 
 /// An asynchronous I/O wrapped CanSocket
 #[derive(Debug)]
-pub struct AsyncCanSocket<T: Socket>(AsyncFd<EventedCanSocket<T>>);
+pub struct AsyncCanSocket<T: Socket>(AsyncFd<T>);
 
 impl<T: Socket + From<OwnedFd>> AsyncCanSocket<T> {
     /// Open a named CAN device such as "can0, "vcan0", etc
     pub fn open(ifname: &str) -> IoResult<Self> {
         let sock = T::open(ifname)?;
         sock.set_nonblocking(true)?;
-        Ok(Self(AsyncFd::new(EventedCanSocket(sock))?))
+        Ok(Self(AsyncFd::new(sock)?))
     }
 
     /// Open CAN device by kernel interface number
     pub fn open_if(ifindex: u32) -> IoResult<Self> {
         let sock = T::open_iface(ifindex)?;
         sock.set_nonblocking(true)?;
-        Ok(Self(AsyncFd::new(EventedCanSocket(sock))?))
+        Ok(Self(AsyncFd::new(sock)?))
     }
 
     /// Open a CAN socket by address
     pub fn open_addr(addr: &CanAddr) -> IoResult<Self> {
         let sock = T::open_addr(addr)?;
         sock.set_nonblocking(true)?;
-        Ok(Self(AsyncFd::new(EventedCanSocket(sock))?))
-    }
-
-    /// Clone the Async Socket by using the `dup` syscall to get another
-    /// file descriptor. This method makes clones fairly cheap and
-    /// avoids complexity around ownership
-    fn try_clone(&self) -> Result<Self> {
-        let fd = self.as_raw_fd();
-        unsafe {
-            // essentially we're cheating and making it cheaper/easier
-            // to manage multiple references to the socket by relying
-            // on the posix behaviour of `dup()` which essentially lets
-            // the kernel worry about keeping track of references;
-            // as long as one of the duplicated file descriptors is open
-            // the socket as a whole isn't going to be closed.
-            let new_fd = OwnedFd::from_raw_fd(libc::dup(fd));
-            let new = T::from(new_fd);
-            Ok(Self(AsyncFd::new(EventedCanSocket(new))?))
-        }
+        Ok(Self(AsyncFd::new(sock)?))
     }
 }
 
@@ -148,7 +72,7 @@ impl<T: Socket> SocketOptions for AsyncCanSocket<T> {}
 
 impl<T: Socket> AsRawFd for AsyncCanSocket<T> {
     fn as_raw_fd(&self) -> RawFd {
-        self.0.get_ref().0.as_raw_fd()
+        self.0.as_raw_fd()
     }
 }
 
@@ -157,14 +81,17 @@ pub type CanSocket = AsyncCanSocket<crate::CanSocket>;
 
 impl CanSocket {
     /// Write a CAN frame to the socket asynchronously
-    ///
-    /// This uses the semantics of socketcan's `write_frame_insist`,
-    /// IE: it will automatically retry when it fails on an EINTR
-    pub fn write_frame(&self, frame: CanFrame) -> Result<CanWriteFuture> {
-        Ok(CanWriteFuture {
-            socket: self.try_clone()?,
-            frame,
-        })
+    pub async fn write_frame(&self, frame: CanFrame) -> IoResult<()> {
+        self.0
+            .async_io(Interest::WRITABLE, |inner| inner.write_frame(&frame))
+            .await
+    }
+
+    /// Read a CAN frame from the socket asynchronously
+    pub async fn read_frame(&self) -> IoResult<CanFrame> {
+        self.0
+            .async_io(Interest::READABLE, |inner| inner.read_frame())
+            .await
     }
 }
 
@@ -174,7 +101,7 @@ impl Stream for CanSocket {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         loop {
             let mut ready_guard = ready!(self.0.poll_read_ready(cx))?;
-            match ready_guard.try_io(|inner| inner.get_ref().get_ref().read_frame()) {
+            match ready_guard.try_io(|inner| inner.get_ref().read_frame()) {
                 Ok(result) => return Poll::Ready(Some(result.map_err(|e| e.into()))),
                 Err(_would_block) => continue,
             }
@@ -201,7 +128,7 @@ impl Sink<CanFrame> for CanSocket {
     }
 
     fn start_send(self: Pin<&mut Self>, item: CanFrame) -> Result<()> {
-        self.0.get_ref().0.write_frame_insist(&item)?;
+        self.0.get_ref().write_frame_insist(&item)?;
         Ok(())
     }
 }
@@ -211,35 +138,17 @@ pub type CanFdSocket = AsyncCanSocket<crate::CanFdSocket>;
 
 impl CanFdSocket {
     /// Write a CAN FD frame to the socket asynchronously
-    ///
-    /// This uses the semantics of socketcan's `write_frame_insist`,
-    /// IE: it will automatically retry when it fails on an EINTR
-    pub fn write_frame(&self, frame: CanFdFrame) -> Result<CanFdWriteFuture> {
-        Ok(CanFdWriteFuture {
-            socket: self.try_clone()?,
-            frame,
-        })
+    pub async fn write_frame(&self, frame: CanFdFrame) -> IoResult<()> {
+        self.0
+            .async_io(Interest::WRITABLE, |inner| inner.write_frame(&frame))
+            .await
     }
-}
 
-/// A Future representing the eventual writing of a CanFdFrame to the socket.
-///
-/// Created by the CanFdSocket.write_frame() method
-#[derive(Debug)]
-pub struct CanFdWriteFuture {
-    socket: CanFdSocket,
-    frame: CanFdFrame,
-}
-
-impl Future for CanFdWriteFuture {
-    type Output = IoResult<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let _ = ready!(self.socket.0.poll_write_ready(cx))?;
-        match self.socket.0.get_ref().0.write_frame_insist(&self.frame) {
-            Ok(_) => Poll::Ready(Ok(())),
-            Err(err) => Poll::Ready(Err(err)),
-        }
+    /// Reads a CAN FD frame from the socket asynchronously
+    pub async fn read_frame(&self) -> IoResult<CanAnyFrame> {
+        self.0
+            .async_io(Interest::READABLE, |inner| inner.read_frame())
+            .await
     }
 }
 
@@ -249,7 +158,7 @@ impl Stream for CanFdSocket {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         loop {
             let mut ready_guard = ready!(self.0.poll_read_ready(cx))?;
-            match ready_guard.try_io(|inner| inner.get_ref().get_ref().read_frame()) {
+            match ready_guard.try_io(|inner| inner.get_ref().read_frame()) {
                 Ok(result) => return Poll::Ready(Some(result.map_err(|e| e.into()))),
                 Err(_would_block) => continue,
             }
@@ -276,7 +185,7 @@ impl Sink<CanFdFrame> for CanFdSocket {
     }
 
     fn start_send(self: Pin<&mut Self>, item: CanFdFrame) -> Result<()> {
-        self.0.get_ref().0.write_frame_insist(&item)?;
+        self.0.get_ref().write_frame_insist(&item)?;
         Ok(())
     }
 }
@@ -296,8 +205,24 @@ mod tests {
 
     const TIMEOUT: Duration = Duration::from_millis(100);
 
+    /// Receive a frame from the CanSocket using the `Stream` trait
+    async fn recv_frame_with_stream(mut socket: CanSocket) -> Result<CanSocket> {
+        select!(
+            frame = socket.next().fuse() => if let Some(_frame) = frame { Ok(socket) } else { panic!("unexpected") },
+            _timeout = Delay::new(TIMEOUT).fuse() => Err(IoErrorKind::TimedOut.into()),
+        )
+    }
+
     /// Receive a frame from the CanSocket
-    async fn recv_frame(mut socket: CanSocket) -> Result<CanSocket> {
+    async fn recv_frame(socket: CanSocket) -> Result<CanSocket> {
+        select!(
+            frame = socket.read_frame().fuse() => if let Ok(_frame) = frame { Ok(socket) } else { panic!("unexpected") },
+            _timeout = Delay::new(TIMEOUT).fuse() => Err(IoErrorKind::TimedOut.into()),
+        )
+    }
+
+    /// Receive a frame from the CanFdSocket using the `Stream` trait
+    async fn recv_frame_fd_with_stream(mut socket: CanFdSocket) -> Result<CanFdSocket> {
         select!(
             frame = socket.next().fuse() => if let Some(_frame) = frame { Ok(socket) } else { panic!("unexpected") },
             _timeout = Delay::new(TIMEOUT).fuse() => Err(IoErrorKind::TimedOut.into()),
@@ -305,9 +230,9 @@ mod tests {
     }
 
     /// Receive a frame from the CanFdSocket
-    async fn recv_frame_fd(mut socket: CanFdSocket) -> Result<CanFdSocket> {
+    async fn recv_frame_fd(socket: CanFdSocket) -> Result<CanFdSocket> {
         select!(
-            frame = socket.next().fuse() => if let Some(_frame) = frame { Ok(socket) } else { panic!("unexpected") },
+            frame = socket.read_frame().fuse() => if let Ok(_frame) = frame { Ok(socket) } else { panic!("unexpected") },
             _timeout = Delay::new(TIMEOUT).fuse() => Err(IoErrorKind::TimedOut.into()),
         )
     }
@@ -315,7 +240,7 @@ mod tests {
     /// Write a test frame to the CanSocket
     async fn write_frame(socket: &CanSocket) -> Result<()> {
         let test_frame = CanFrame::new(StandardId::new(0x1).unwrap(), &[0]).unwrap();
-        socket.write_frame(test_frame)?.await?;
+        socket.write_frame(test_frame).await?;
         Ok(())
     }
 
@@ -323,13 +248,10 @@ mod tests {
     async fn write_frame_fd(socket: &CanFdSocket) -> Result<()> {
         let test_frame =
             CanFdFrame::new(StandardId::new(0x1).unwrap(), &[0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap();
-        socket.write_frame(test_frame)?.await?;
+        socket.write_frame(test_frame).await?;
         Ok(())
     }
 
-    /// Attempt delivery of two messages, using a oneshot channel
-    /// to prompt the second message in order to demonstrate that
-    /// waiting for CAN reads is not blocking.
     #[serial]
     #[tokio::test]
     async fn test_receive() -> Result<()> {
@@ -351,6 +273,25 @@ mod tests {
 
     #[serial]
     #[tokio::test]
+    async fn test_receive_with_stream() -> Result<()> {
+        let socket1 = CanSocket::open("vcan0").unwrap();
+        let socket2 = CanSocket::open("vcan0").unwrap();
+
+        let send_frames = future::try_join(write_frame(&socket1), write_frame(&socket1));
+
+        let recv_frames = async {
+            let socket2 = recv_frame_with_stream(socket2).await?;
+            let _socket2 = recv_frame_with_stream(socket2).await;
+            Ok(())
+        };
+
+        try_join!(recv_frames, send_frames)?;
+
+        Ok(())
+    }
+
+    #[serial]
+    #[tokio::test]
     async fn test_receive_can_fd() -> Result<()> {
         let socket1 = CanFdSocket::open("vcan0").unwrap();
         let socket2 = CanFdSocket::open("vcan0").unwrap();
@@ -360,6 +301,25 @@ mod tests {
         let recv_frames = async {
             let socket2 = recv_frame_fd(socket2).await?;
             let _socket2 = recv_frame_fd(socket2).await;
+            Ok(())
+        };
+
+        try_join!(recv_frames, send_frames)?;
+
+        Ok(())
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn test_receive_can_fd_with_stream() -> Result<()> {
+        let socket1 = CanFdSocket::open("vcan0").unwrap();
+        let socket2 = CanFdSocket::open("vcan0").unwrap();
+
+        let send_frames = future::try_join(write_frame_fd(&socket1), write_frame_fd(&socket1));
+
+        let recv_frames = async {
+            let socket2 = recv_frame_fd_with_stream(socket2).await?;
+            let _socket2 = recv_frame_fd_with_stream(socket2).await;
             Ok(())
         };
 


### PR DESCRIPTION
Hello,

I was studying the tokio async implementation for the `CanSocket`/`CanFdSocket` and noticed that the implementation seems out of date compared to what the current tokio API offers (using the `AsyncFd`). Instead of having the intermediate `EventedCanSocket` wrapper, which implements a mio event source, I directly used the appropriate functions on the `AsyncFd`. I could not figure out why the mio event source was used as an intermediate wrapper. My only guess is that the code was merged from the tokio-socketcan crate, which wasn't updated for a long time, and was written against an older API of tokio/mio. If I am wrong here and the code was necessary for some reason, please let me know!

When working on it, I also added a new method for reading a single frame asynchronously, which was only possible through the `Stream` trait before.

I added two new test for the `read_frame` functions of `CanSocket` and `CanFdSocket` and renamed the old one to reflect that they use the Stream interface.

This PR includes a breaking change because the return type of the `write_frame` function changes, see code in the examples. 