### PR TITLE
remove unnecessary qualifications

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -91,7 +91,7 @@ pub type IoError = io::Error;
 pub type IoErrorKind = io::ErrorKind;
 
 /// An I/O specific result
-pub type IoResult<T> = std::io::Result<T>;
+pub type IoResult<T> = io::Result<T>;
 
 // ===== CanError ====
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -130,7 +130,7 @@ pub trait AsPtr {
 
     /// The size of the inner type
     fn size(&self) -> usize {
-        std::mem::size_of::<Self::Inner>()
+        mem::size_of::<Self::Inner>()
     }
 
     /// Gets a byte slice to the inner type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ impl embedded_can::nb::Can for CanSocket {
                     ErrorKind::WouldBlock => Err(nb::Error::WouldBlock),
                     // TODO: How to indicate buffer is full?
                     // ErrorKind::StorageFull => Ok(frame),
-                    _ => Err(crate::Error::from(err).into()),
+                    _ => Err(Error::from(err).into()),
                 }
             }
         }

--- a/src/nl/rt.rs
+++ b/src/nl/rt.rs
@@ -94,7 +94,7 @@ impl<'a> FromBytes<'a> for can_bittiming_const {
 
 impl Size for can_bittiming_const {
     fn unpadded_size(&self) -> usize {
-        std::mem::size_of::<can_bittiming_const>()
+        mem::size_of::<can_bittiming_const>()
     }
 }
 


### PR DESCRIPTION
While compiling with rustc version 1.78 i got these errors related to unnecessary qualifications, hence i removed these qualifications.