### PR TITLE
Update some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ byte_conv = "0.1.1"
 hex = "0.4"
 itertools = "0.10"
 libc = "0.2"
-nix = "0.26"
+nix = { version="0.29", features = ["poll", "process", "net"] }
 bitflags = "1.3"
 thiserror = "1.0"
 socket2 = { version = "0.5", features = ["all"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,17 +41,17 @@ nb = "1"
 log = "0.4"
 byte_conv = "0.1.1"
 hex = "0.4"
-itertools = "0.10"
+itertools = "0.13"
 libc = "0.2"
 nix = { version="0.29", features = ["poll", "process", "net"] }
-bitflags = "1.3"
+bitflags = "2.6"
 thiserror = "1.0"
 socket2 = { version = "0.5", features = ["all"] }
 clap = { version = "3.2", optional = true }
-anyhow = { version = "1.0", optional = true }
+anyhow = { version = "1", optional = true }
 neli = { version = "0.6", optional = true }
 tokio = { version = "1", features = ["net"], optional = true }
-mio = { version = "0.8", features = ["os-ext"], optional = true }
+mio = { version = "1", features = ["os-ext"], optional = true }
 futures = { version = "0.3", optional = true }
 async-io = { version = "1.13", optional = true }
 smol = { version = "1.3", optional = true }

--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -429,7 +429,7 @@ impl CanInterface {
     /// has specific, non-default, generic parameters.
     fn open_route_socket<T, P>() -> Result<NlSocketHandle, NlError<T, P>> {
         // retrieve PID
-        let pid = unistd::getpid().as_raw() as u32;
+        let pid = unistd::Pid::this().as_raw() as u32;
 
         // open and bind socket
         // groups is set to None(0), because we want no notifications
@@ -641,7 +641,7 @@ impl CanInterface {
     /// Set a CAN-specific set of parameters.
     ///
     /// This sends a netlink message down to the kernel to set multiple
-    /// attributes in the link info, such as bitrate, control modes, etc. 
+    /// attributes in the link info, such as bitrate, control modes, etc.
     ///
     /// If you have many attributes to set this is preferred to calling
     /// [set_can_params][CanInterface::set_can_param] multiple times, since this only sends a


### PR DESCRIPTION
This crate is causing a lot of duplicate dependencies in our trees since it uses outdated versions of some very common libraries.

This PR updates these dependencies to their latest version. Only the `nix` dependency required some code changes.