### PR TITLE
Friendly non linux compilation error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ itertools = "0.13"
 libc = "0.2"
 nix = { version="0.29", features = ["poll", "process", "net"] }
 bitflags = "2.6"
-thiserror = "1.0"
+thiserror = "2"
 socket2 = { version = "0.5", features = ["all"] }
 clap = { version = "3.2", optional = true }
 anyhow = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ enumerate = ["dep:libudev"]
 embedded-can = "0.4"
 nb = "1"
 log = "0.4"
-byte_conv = "0.1.1"
 hex = "0.4"
 itertools = "0.13"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ thiserror = "2"
 socket2 = { version = "0.5", features = ["all"] }
 clap = { version = "3.2", optional = true }
 anyhow = { version = "1", optional = true }
-neli = { version = "0.6", optional = true }
 tokio = { version = "1", features = ["net"], optional = true }
 mio = { version = "1", features = ["os-ext"], optional = true }
 futures = { version = "0.3", optional = true }
@@ -56,6 +55,12 @@ async-io = { version = "1.13", optional = true }
 smol = { version = "1.3", optional = true }
 async-std = { version = "1.12", optional = true }
 libudev = { version = "0.3", optional = true }
+
+# This hack avoids building neli on non-linux platforms, which
+# avoids a ton of compile errors. Worthwhile together with the
+# build.rs script to error early when building for non-linux
+[target.'cfg(target_os = "linux")'.dependencies]
+neli = { version = "0.6", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+    match std::env::var("CARGO_CFG_TARGET_OS") {
+        Ok(val) if val == "linux" => Ok(()),
+        _ => Err("Building for anything but Linux is not supported by socketcan".into()),
+    }
+}


### PR DESCRIPTION
I tried to make it a bit friendlier for someone accidentally building on non-linux by adding a build script to check and only including neli for linux. Also this removes an unused and very outdated dependency as well as updating thiserror to version 2, which has permeated through the ecosystem quite a bit