### PR TITLE
better error parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ bitflags = "2.6"
 thiserror = "2"
 num-traits = "0.2.19"
 num-derive = "0.4.2"
+strum = "0.27.1"
+strum_macros = "0.27.1"
 socket2 = { version = "0.5", features = ["all"] }
 clap = { version = "3.2", optional = true }
 anyhow = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ libc = "0.2"
 nix = { version="0.29", features = ["poll", "process", "net"] }
 bitflags = "2.6"
 thiserror = "2"
+num-traits = "0.2.19"
+num-derive = "0.4.2"
 socket2 = { version = "0.5", features = ["all"] }
 clap = { version = "3.2", optional = true }
 anyhow = { version = "1", optional = true }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,26 +37,6 @@
 //! from the Linux kernel header file:
 //! [linux/can/error.h](https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/can/error.h)
 //!
-//! see also snprintf_can_error_frame() in https://github.com/linux-can/can-utils/blob/master/lib.c
-//! for the types of errors that can coexist in a single error frame:
-//! 1. prints the error class
-//! 2. prints informtion for each of CAN_ERR_LOSTARB, CAN_ERR_CRTL, CAN_ERR_PROT, CAN_ERR_CNT, if flags are set
-//! 3. prints error counts if they're nonzero even if CAN_ERR_CNT wasn't set
-//! 
-//! for example:
-//! cansend vcan0 200001FF#0011223344556677 (would be "3FF" for all flags, but a bug in 2023 and earlier cansend versions prevents printing if CAN_ERR_CNT is set)
-//! prints: (with candump -c -ta -H -d -e -x vcan0,0:0,#FFFFFFFF)
-//!  (0000000000.000000)  vcan0  TX - -  200001FF   [8]  00 11 22 33 44 55 66 77   ERRORFRAME
-//!  	tx-timeout
-//!  	lost-arbitration{at bit 0}
-//!  	controller-problem{rx-overflow,rx-error-passive}
-//!  	protocol-violation{{frame-format-error,bus-overload}{}}
-//!  	transceiver-status
-//!  	no-acknowledgement-on-tx
-//!  	bus-off
-//!  	bus-error
-//!  	restarted-after-bus-off
-//!  	error-counter-tx-rx{{102}{119}}
 
 use num_derive::FromPrimitive;    
 use num_traits::FromPrimitive;
@@ -219,8 +199,8 @@ impl fmt::Display for CanError {
         }
         if let Some(ref protocol_violation) = self.protocol_violation {
             parts.push(format!(
-                "protocol violation at {}: {}",
-                protocol_violation.location, protocol_violation.vtype
+                "protocol violation: {} at {}",
+                protocol_violation.vtype, protocol_violation.location
             ));
         }
         if let Some(ref transceiver_error) = self.transceiver_error {
@@ -719,8 +699,12 @@ impl fmt::Display for ConstructionError {
 
 #[cfg(test)]
 mod tests {
-    use crate::Error;
+    use embedded_can::{ExtendedId, Frame};
+
+    use crate::{CanErrorFrame, Error};
     use std::io;
+
+    use super::CanError;
 
     #[test]
     fn test_errors() {
@@ -741,5 +725,49 @@ mod tests {
         } else {
             panic!("Wrong error conversion");
         }
+    }
+
+    #[test]
+    fn test_error_printing() {
+        // see snprintf_can_error_frame() in https://github.com/linux-can/can-utils/blob/master/lib.c
+        // for the types of errors that can coexist in a single error frame, snprintf_can_error_frame():
+        // 1. prints the error class
+        // 2. prints information for each of CAN_ERR_LOSTARB, CAN_ERR_CRTL, CAN_ERR_PROT, CAN_ERR_CNT, if flags are set
+        //  a. CAN_ERR_TRX details in data[4] aren't printed (I think this is an omission)
+        // 3. prints error counts if they're nonzero even if CAN_ERR_CNT wasn't set
+        // 
+        // for example:
+        // candump -c -ta -H -d -e -x vcan0,0:0,#FFFFFFFF &
+        // cansend vcan0 200001FF#00.01.02.03.04.05.06.07 (would be "3FF" for all flags, but a bug in 2023 and earlier cansend versions prevents printing if CAN_ERR_CNT is set)
+        // prints:
+        // (0000000000.000000)  vcan0  TX - -  200001FF   [8]  00 01 02 03 04 05 06 07   ERRORFRAME
+        //     tx-timeout
+        //     lost-arbitration{at bit 0}
+        //     controller-problem{rx-overflow}
+        //     protocol-violation{{frame-format-error}{start-of-frame}}
+        //     transceiver-status
+        //     no-acknowledgement-on-tx
+        //     bus-off
+        //     bus-error
+        //     restarted-after-bus-off
+        //     error-counter-tx-rx{{6}{7}}
+
+        // create a can frame with id 200001FF and data 00 01 02 03 04 05 06 07 to match the candump test value above
+        let id = ExtendedId::new(0x1FF).unwrap(); // the leading 0x2 CAN_ERR_FLAG is built in
+        let frame = CanErrorFrame::new(id, &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]).unwrap();
+
+        // get a canerror from it
+        let can_error: CanError = frame.into();
+        // print it
+        assert_eq!(format!("{}", can_error), r#"transmission timeout
+arbitration lost at bit 0
+controller problem: receive buffer overflow
+protocol violation: frame format error at start of frame
+transceiver error: CAN High, no wire
+no ack on tx
+bus off
+bus error
+restarted after bus off
+error counts: tx 6, rx 7"#);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,6 +40,8 @@
 
 use num_derive::FromPrimitive;    
 use num_traits::FromPrimitive;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 use crate::{CanErrorFrame, EmbeddedFrame, Frame};
 use std::{convert::TryFrom, error, fmt, io};
 use thiserror::Error;
@@ -134,7 +136,7 @@ pub enum CanErrorFlags {
     /// Controller restarted
     Restarted = 0x00000100,
     /// TX error counter / data[6] RX error counter / data[7]
-    TxErrorCounter = 0x00000200,
+    ErrorCounter = 0x00000200,
 }
 
 // ===== CanError ====
@@ -157,14 +159,16 @@ pub enum CanErrorFlags {
 pub struct CanError {
     /// TX timeout (by netdevice driver)
     pub transmit_timeout: bool,
-    /// Arbitration was lost.
+    /// Arbitration was lost. data[0]
     /// Contains the bit number after which arbitration was lost or 0 if unspecified.
     pub lost_arbitration: Option<LostArbitration>,
-    /// Controller problem
-    pub controller_problem: Option<ControllerProblem>,
-    /// Protocol violation at the specified [`Location`].
-    pub protocol_violation: Option<ProtocolViolation>,
-    /// Transceiver Error.
+    /// Controller problem(s) data[1]
+    pub controller_problems: Vec<ControllerProblem>,
+    /// Protocol violation(s) at the specified [`Location`] data[2]
+    pub protocol_violations: Vec<ViolationType>,
+    /// protocol violation location data[3]
+    pub location: Option<Location>,
+    /// Transceiver Error
     pub transceiver_error: Option<TransceiverError>,
     /// No ACK received for current CAN frame.
     pub no_ack: bool,
@@ -174,10 +178,10 @@ pub struct CanError {
     pub bus_error: bool,
     /// The bus has been restarted
     pub restarted: bool,
-    /// error counters. either the bit is set with any byte[6-7] contents, or the bytes 6-7 are nonzero
+    /// error counters, tx data[6] and rx data[7]. filled if either the CAN_ERR_CNT bit is set or bytes 6-7 are nonzero
     pub error_counts: Option<ErrorCounts>,    
     /// list of errors decoding the error frame
-    pub decoding_failure: Vec<CanErrorDecodingFailure>,
+    pub decoding_failures: Vec<CanErrorDecodingFailure>,
     /// Unknown, possibly invalid, error
     pub unknown: Option<u32>,
 }
@@ -194,14 +198,44 @@ impl fmt::Display for CanError {
         if let Some(ref lost_arbitration) = self.lost_arbitration {
             parts.push(format!("arbitration lost at bit {}", lost_arbitration.bit));
         }
-        if let Some(ref controller_problem) = self.controller_problem {
-            parts.push(format!("controller problem: {}", controller_problem));
-        }
-        if let Some(ref protocol_violation) = self.protocol_violation {
-            parts.push(format!(
-                "protocol violation: {} at {}",
-                protocol_violation.vtype, protocol_violation.location
+        if !self.controller_problems.is_empty() {
+            let mut controller_problems_line: String = String::new();
+            if self.controller_problems.len() > 1 {
+                controller_problems_line.push_str("multiple controller problems: ");
+            } else {
+                controller_problems_line.push_str("controller problem: ");
+            }
+            controller_problems_line.push_str(&format!(
+                "{}",
+                self.controller_problems
+                    .iter()
+                    .map(|err| format!("{}", err))
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
+            parts.push(controller_problems_line);
+        }
+        if !self.protocol_violations.is_empty() {
+            let mut protocol_violations_line: String = String::new();
+            if self.protocol_violations.len() > 1 {
+                protocol_violations_line.push_str("multiple protocol violations: ");
+            } else {
+                protocol_violations_line.push_str("protocol violation: ");
+            }
+            protocol_violations_line.push_str(&format!(
+                "{}",
+                self.protocol_violations
+                    .iter()
+                    .map(|err| format!("{}", err))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+            if let Some(ref location) = self.location {
+                protocol_violations_line.push_str(&format!(" at {}", location));
+            } else {
+                protocol_violations_line.push_str(" (location decoding failed)");
+            }
+            parts.push(protocol_violations_line);
         }
         if let Some(ref transceiver_error) = self.transceiver_error {
             parts.push(format!("transceiver error: {}", transceiver_error));
@@ -221,7 +255,7 @@ impl fmt::Display for CanError {
         if let Some(ref error_counts) = self.error_counts {
             parts.push(format!("error counts: tx {}, rx {}", error_counts.tx, error_counts.rx));
         }
-        for err in &self.decoding_failure {
+        for err in &self.decoding_failures {
             parts.push(format!("decoding failure: {}", err));
         }
         if let Some(ref unknown) = self.unknown {
@@ -235,15 +269,17 @@ impl fmt::Display for CanError {
 impl embedded_can::Error for CanError {
     fn kind(&self) -> embedded_can::ErrorKind {
         // a single error frame could translate multiple ways. just match the first way found
-        if let Some(controller_problem) = self.controller_problem {
+        // there are problably a few more translations possible
+        if !self.controller_problems.is_empty() {
             use ControllerProblem::*;
-            match controller_problem {
-                ReceiveBufferOverflow | TransmitBufferOverflow => {
+            for controller_problem in &self.controller_problems {
+                if *controller_problem == ReceiveBufferOverflow || *controller_problem == TransmitBufferOverflow {
                     return embedded_can::ErrorKind::Overrun
                 }
-                _ => return embedded_can::ErrorKind::Other,
             }
+            return embedded_can::ErrorKind::Other;
         }
+
         if self.no_ack {
             return embedded_can::ErrorKind::Acknowledge;
         }
@@ -266,27 +302,38 @@ impl From<CanErrorFrame> for CanError {
             });
         }
         if (frame.error_bits() & (CanErrorFlags::ControllerProblems as u32)) != 0 {
-            match ControllerProblem::try_from(frame.data()[1]) {
-                Ok(err) => can_error.controller_problem = Some(err),
-                Err(err) => can_error.decoding_failure.push(err),
+            for problem in ControllerProblem::iter() {
+                if (frame.data()[1] & problem as u8) != 0 {
+                    can_error.controller_problems.push(problem);
+                }
+            }
+            // CAN_ERR_CRTL is set, but no controller problems were found
+            if can_error.controller_problems.is_empty() {
+                can_error.decoding_failures.push(CanErrorDecodingFailure::CtrlBitSetButNoneFound);
             }
         }
         if (frame.error_bits() & (CanErrorFlags::ProtocolViolations as u32)) != 0 {
-            match (
-                ViolationType::try_from(frame.data()[2]),
-                Location::try_from(frame.data()[3]),
-            ) {
-                (Ok(vtype), Ok(location)) => can_error.protocol_violation = Some(ProtocolViolation {
-                    vtype,
-                    location,
-                }),
-                (Err(err), _) | (_, Err(err)) => can_error.decoding_failure.push(err),
+            for vtype in ViolationType::iter() {
+                if (frame.data()[2] & vtype as u8) != 0 {
+                    can_error.protocol_violations.push(vtype);
+                }
+            }
+            // CAN_ERR_PROT is set, but no protocol violations were found
+            if can_error.protocol_violations.is_empty() {
+                can_error.decoding_failures.push(CanErrorDecodingFailure::ProtBitSetButNoneFound);
+            }
+            match Location::try_from(frame.data()[3]) {
+                Ok(location) => can_error.location = Some(location),
+                Err(err) => {
+                    can_error.decoding_failures.push(err);
+                    // leave location as None
+                }
             }
         }
         if (frame.error_bits() & (CanErrorFlags::TransceiverStatus as u32)) != 0 {
             match TransceiverError::try_from(frame.data()[4]) {
                 Ok(err) => can_error.transceiver_error = Some(err),
-                Err(err) => can_error.decoding_failure.push(err),
+                Err(err) => can_error.decoding_failures.push(err),
             }
         }
         if (frame.error_bits() & (CanErrorFlags::NoAck as u32)) != 0 {
@@ -301,7 +348,7 @@ impl From<CanErrorFrame> for CanError {
         if (frame.error_bits() & (CanErrorFlags::Restarted as u32)) != 0 {
             can_error.restarted = true;
         }
-        if (frame.error_bits() & (CanErrorFlags::TxErrorCounter as u32)) != 0 {
+        if (frame.error_bits() & (CanErrorFlags::ErrorCounter as u32)) != 0 {
             can_error.error_counts = Some(ErrorCounts {
                 tx: frame.data()[6],
                 rx: frame.data()[7],
@@ -325,15 +372,14 @@ pub struct LostArbitration {
     pub bit: u8,
 }
 
-// todo impls
-
 // ===== ControllerProblem =====
 
 /// Error status of the CAN controller.
 ///
 /// This is derived from `data[1]` of an error frame
+/// the flags don't conflict so there can be multiple problems
 /// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, FromPrimitive, EnumIter)]
 #[repr(u8)]
 pub enum ControllerProblem {
     /// unspecified
@@ -372,34 +418,12 @@ impl fmt::Display for ControllerProblem {
     }
 }
 
-impl TryFrom<u8> for ControllerProblem {
-    type Error = CanErrorDecodingFailure;
-
-    fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
-        ControllerProblem::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidControllerProblem)
-    }
-}
-
-// ===== ProtocolViolation =====
-
-/// populated if CAN_ERR_PROT is set
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ProtocolViolation {
-    /// The type of protocol violation
-    pub vtype: ViolationType,
-    /// The location (field or bit) of the violation
-    pub location: Location,
-}
-
-// todo impls
-
 // ===== ViolationType =====
 
-/// The type of protocol violation error.
-///
-/// This is derived from `data[2]` of an error frame.
+/// populated if CAN_ERR_PROT is set. This is derived from `data[2]` of an error frame.
+/// the flags don't conflict so there can be multiple types, but only one location (in data[3])
 /// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, EnumIter)]
 #[repr(u8)]
 pub enum ViolationType {
     /// Unspecified Violation
@@ -439,13 +463,6 @@ impl fmt::Display for ViolationType {
             TransmissionError => "transmission error",
         };
         write!(f, "{}", msg)
-    }
-}
-impl TryFrom<u8> for ViolationType {
-    type Error = CanErrorDecodingFailure;
-
-    fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
-        ViolationType::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidProtocolViolationType)
     }
 }
 
@@ -627,11 +644,10 @@ pub enum CanErrorDecodingFailure {
     /// The error type indicated a need for additional information as `data`,
     /// but the `data` field was not long enough.
     NotEnoughData(u8),
-    /// The error type `ControllerProblem` was indicated and additional
-    /// information found, but not recognized.
-    InvalidControllerProblem,
-    /// The type of the ProtocolViolation was not valid
-    InvalidProtocolViolationType,
+    /// The error type `ControllerProblem` was indicated but none of the data[1] bits decoded to any problem
+    CtrlBitSetButNoneFound,
+    /// the error type `ProtocolViolation` was indicated but none of the data[2] bits decoded to a valid type
+    ProtBitSetButNoneFound,
     /// A location was specified for a ProtocolViolation, but the location
     /// was not valid.
     InvalidProtocolViolationLocation,
@@ -648,8 +664,8 @@ impl fmt::Display for CanErrorDecodingFailure {
             NotAnError => "CAN frame is not an error",
             UnknownErrorType(_) => "unknown error type",
             NotEnoughData(_) => "not enough data",
-            InvalidControllerProblem => "not a valid controller problem",
-            InvalidProtocolViolationType => "not a valid protocol violation type",
+            CtrlBitSetButNoneFound => "controller problem bit set, but no problems found",
+            ProtBitSetButNoneFound => "protocol problem bit set, but no violations found",
             InvalidProtocolViolationLocation => "not a valid protocol violation location",
             InvalidTransceiverError => "not a valid transceiver error",
         };
@@ -665,8 +681,6 @@ pub struct ErrorCounts {
     /// RX error counter data[7]
     pub rx: u8,
 }
-
-// todo impls
 
 // ===== ConstructionError =====
 
@@ -790,13 +804,14 @@ error counts: tx 6, rx 7"#);
         let can_error: CanError = frame.into();
         assert_eq!(format!("{}", can_error), r#"transmission timeout
 arbitration lost at bit 254
+multiple controller problems: transmit buffer overflow, ERROR WARNING (receive), ERROR WARNING (transmit), ERROR PASSIVE (receive), ERROR PASSIVE (transmit), ERROR ACTIVE
+multiple protocol violations: frame format error, bit stuffing error, unable to send dominant bit, unable to send recessive bit, bus overload, active, transmission error (location decoding failed)
 no ack on tx
 bus off
 bus error
 restarted after bus off
 error counts: tx 254, rx 254
-decoding failure: not a valid controller problem
-decoding failure: not a valid protocol violation type
+decoding failure: not a valid protocol violation location
 decoding failure: not a valid transceiver error"#);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -445,7 +445,7 @@ impl TryFrom<u8> for ViolationType {
     type Error = CanErrorDecodingFailure;
 
     fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
-        ViolationType::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidViolationType)
+        ViolationType::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidProtocolViolationType)
     }
 }
 
@@ -534,7 +534,7 @@ impl TryFrom<u8> for Location {
     type Error = CanErrorDecodingFailure;
 
     fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
-        Location::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidLocation)
+        Location::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidProtocolViolationLocation)
     }
 }
 
@@ -631,10 +631,10 @@ pub enum CanErrorDecodingFailure {
     /// information found, but not recognized.
     InvalidControllerProblem,
     /// The type of the ProtocolViolation was not valid
-    InvalidViolationType,
+    InvalidProtocolViolationType,
     /// A location was specified for a ProtocolViolation, but the location
     /// was not valid.
-    InvalidLocation,
+    InvalidProtocolViolationLocation,
     /// The supplied transceiver error was invalid.
     InvalidTransceiverError,
 }
@@ -649,8 +649,8 @@ impl fmt::Display for CanErrorDecodingFailure {
             UnknownErrorType(_) => "unknown error type",
             NotEnoughData(_) => "not enough data",
             InvalidControllerProblem => "not a valid controller problem",
-            InvalidViolationType => "not a valid violation type",
-            InvalidLocation => "not a valid location",
+            InvalidProtocolViolationType => "not a valid protocol violation type",
+            InvalidProtocolViolationLocation => "not a valid protocol violation location",
             InvalidTransceiverError => "not a valid transceiver error",
         };
         write!(f, "{}", msg)
@@ -741,24 +741,22 @@ mod tests {
         // cansend vcan0 200001FF#00.01.02.03.04.05.06.07 (would be "3FF" for all flags, but a bug in 2023 and earlier cansend versions prevents printing if CAN_ERR_CNT is set)
         // prints:
         // (0000000000.000000)  vcan0  TX - -  200001FF   [8]  00 01 02 03 04 05 06 07   ERRORFRAME
-        //     tx-timeout
-        //     lost-arbitration{at bit 0}
-        //     controller-problem{rx-overflow}
-        //     protocol-violation{{frame-format-error}{start-of-frame}}
-        //     transceiver-status
-        //     no-acknowledgement-on-tx
-        //     bus-off
-        //     bus-error
-        //     restarted-after-bus-off
-        //     error-counter-tx-rx{{6}{7}}
+        //    tx-timeout
+        //    lost-arbitration{at bit 0}
+        //    controller-problem{rx-overflow}
+        //    protocol-violation{{frame-format-error}{start-of-frame}}
+        //    transceiver-status
+        //    no-acknowledgement-on-tx
+        //    bus-off
+        //    bus-error
+        //    restarted-after-bus-off
+        //    error-counter-tx-rx{{6}{7}}
 
         // create a can frame with id 200001FF and data 00 01 02 03 04 05 06 07 to match the candump test value above
         let id = ExtendedId::new(0x1FF).unwrap(); // the leading 0x2 CAN_ERR_FLAG is built in
         let frame = CanErrorFrame::new(id, &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]).unwrap();
 
-        // get a canerror from it
         let can_error: CanError = frame.into();
-        // print it
         assert_eq!(format!("{}", can_error), r#"transmission timeout
 arbitration lost at bit 0
 controller problem: receive buffer overflow
@@ -769,5 +767,36 @@ bus off
 bus error
 restarted after bus off
 error counts: tx 6, rx 7"#);
+
+        // same, but error values where possible
+        // shows multiple controller problems and multiple protocol violations
+        // candump comparison:
+        // candump -c -ta -H -d -e -x vcan0,0:0,#FFFFFFFF &
+        // cansend vcan0 200001FF#FE.FE.FE.FE.FE.FE.FE.FE (would be "3FF" for all flags, but a bug in 2023 and earlier cansend versions prevents printing if CAN_ERR_CNT is set)
+        // prints:
+        // (0000000000.000000)  vcan0  TX - -  200001FF   [8]  FE FE FE FE FE FE FE FE   ERRORFRAME
+        //    tx-timeout
+        //    lost-arbitration{at bit 254}
+        //    controller-problem{tx-overflow,rx-error-warning,tx-error-warning,rx-error-passive,tx-error-passive,back-to-error-active}
+        //    protocol-violation{{frame-format-error,bit-stuffing-error,tx-dominant-bit-error,tx-recessive-bit-error,bus-overload,active-error,error-on-tx}{}}
+        //    transceiver-status
+        //    no-acknowledgement-on-tx
+        //    bus-off
+        //    bus-error
+        //    restarted-after-bus-off
+        //    error-counter-tx-rx{{254}{254}}
+
+        let frame = CanErrorFrame::new(id, &[0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE]).unwrap();
+        let can_error: CanError = frame.into();
+        assert_eq!(format!("{}", can_error), r#"transmission timeout
+arbitration lost at bit 254
+no ack on tx
+bus off
+bus error
+restarted after bus off
+error counts: tx 254, rx 254
+decoding failure: not a valid controller problem
+decoding failure: not a valid protocol violation type
+decoding failure: not a valid transceiver error"#);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -478,7 +478,7 @@ impl fmt::Display for ViolationType {
 pub enum Location {
     /// Unspecified
     Unspecified = 0x00,
-    /// Start of frame.
+    /// Start of frame
     StartOfFrame = 0x03,
     /// ID bits 28-21 (SFF: 10-3)
     Id2821 = 0x02,
@@ -505,7 +505,7 @@ pub enum Location {
     /// Data section
     DataSection = 0x0A,
     /// CRC sequence
-    CrcSequence = 0x008,
+    CrcSequence = 0x08,
     /// CRC delimiter
     CrcDelimiter = 0x18,
     /// ACK slot
@@ -516,6 +516,18 @@ pub enum Location {
     EndOfFrame = 0x1A,
     /// Intermission (between frames)
     Intermission = 0x12,
+
+    /// the following aren't in the current linux error.h but are valid
+    /// Active Error Flag
+    ActiveErrorFlag = 0x11,
+    /// Passive Error Flag
+    PassiveErrorFlag = 0x16,
+    /// Tolerate Dominant Bits
+    TolerateDominantBits = 0x13,
+    /// Error Delimiter
+    ErrorDelimiter = 0x17,
+    /// Overload Flag
+    OverloadFlag = 0x1C,
 }
 
 impl fmt::Display for Location {
@@ -542,6 +554,11 @@ impl fmt::Display for Location {
             AckDelimiter => "ACK delimiter",
             EndOfFrame => "end of frame",
             Intermission => "intermission",
+            ActiveErrorFlag => "active error flag",
+            PassiveErrorFlag => "passive error flag",
+            TolerateDominantBits => "tolerate dominant bits",
+            ErrorDelimiter => "error delimiter",
+            OverloadFlag => "overload flag",
         };
         write!(f, "{}", msg)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -397,7 +397,7 @@ pub enum ControllerProblem {
     /// reached error passive status TX
     TransmitErrorPassive = 0x20,
     /// recovered to error active state
-    Active = 0x40,
+    BackToErrorActive = 0x40,
 }
 
 impl error::Error for ControllerProblem {}
@@ -412,7 +412,7 @@ impl fmt::Display for ControllerProblem {
             TransmitErrorWarning => "ERROR WARNING (transmit)",
             ReceiveErrorPassive => "ERROR PASSIVE (receive)",
             TransmitErrorPassive => "ERROR PASSIVE (transmit)",
-            Active => "ERROR ACTIVE",
+            BackToErrorActive => "back to ERROR ACTIVE",
         };
         write!(f, "{}", msg)
     }
@@ -743,16 +743,18 @@ mod tests {
 
     #[test]
     fn test_error_printing() {
+        // compare our error printing to the printing in linux can-util's C implementation
         // see snprintf_can_error_frame() in https://github.com/linux-can/can-utils/blob/master/lib.c
-        // for the types of errors that can coexist in a single error frame, snprintf_can_error_frame():
+
+        // snprintf_can_error_frame():
         // 1. prints the error class
         // 2. prints information for each of CAN_ERR_LOSTARB, CAN_ERR_CRTL, CAN_ERR_PROT, CAN_ERR_CNT, if flags are set
         //  a. CAN_ERR_TRX details in data[4] aren't printed (I think this is an omission)
         // 3. prints error counts if they're nonzero even if CAN_ERR_CNT wasn't set
-        // 
+
         // for example:
         // candump -c -ta -H -d -e -x vcan0,0:0,#FFFFFFFF &
-        // cansend vcan0 200001FF#00.01.02.03.04.05.06.07 (would be "3FF" for all flags, but a bug in 2023 and earlier cansend versions prevents printing if CAN_ERR_CNT is set)
+        // cansend vcan0 200001FF#00.01.02.03.04.05.06.07 (would be "3FF" for all flags, but a bug in 2023 and earlier candump versions prevents printing if CAN_ERR_CNT is set)
         // prints:
         // (0000000000.000000)  vcan0  TX - -  200001FF   [8]  00 01 02 03 04 05 06 07   ERRORFRAME
         //    tx-timeout
@@ -784,9 +786,10 @@ error counts: tx 6, rx 7"#);
 
         // same, but error values where possible
         // shows multiple controller problems and multiple protocol violations
+
         // candump comparison:
         // candump -c -ta -H -d -e -x vcan0,0:0,#FFFFFFFF &
-        // cansend vcan0 200001FF#FE.FE.FE.FE.FE.FE.FE.FE (would be "3FF" for all flags, but a bug in 2023 and earlier cansend versions prevents printing if CAN_ERR_CNT is set)
+        // cansend vcan0 200001FF#FE.FE.FE.FE.FE.FE.FE.FE (would be "3FF" for all flags, but a bug in 2023 and earlier candump versions prevents printing if CAN_ERR_CNT is set)
         // prints:
         // (0000000000.000000)  vcan0  TX - -  200001FF   [8]  FE FE FE FE FE FE FE FE   ERRORFRAME
         //    tx-timeout
@@ -804,7 +807,7 @@ error counts: tx 6, rx 7"#);
         let can_error: CanError = frame.into();
         assert_eq!(format!("{}", can_error), r#"transmission timeout
 arbitration lost at bit 254
-multiple controller problems: transmit buffer overflow, ERROR WARNING (receive), ERROR WARNING (transmit), ERROR PASSIVE (receive), ERROR PASSIVE (transmit), ERROR ACTIVE
+multiple controller problems: transmit buffer overflow, ERROR WARNING (receive), ERROR WARNING (transmit), ERROR PASSIVE (receive), ERROR PASSIVE (transmit), back to ERROR ACTIVE
 multiple protocol violations: frame format error, bit stuffing error, unable to send dominant bit, unable to send recessive bit, bus overload, active, transmission error (location decoding failed)
 no ack on tx
 bus off

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -559,7 +559,7 @@ impl TryFrom<u8> for Location {
 
 /// The error status of the CAN transceiver.
 ///
-/// This is derived from `data[4]` of an error frame.
+/// This is derived from `data[4]` of an error frame if CAN_ERR_TRX is set
 /// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, FromPrimitive)]
 #[repr(u8)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,7 +37,29 @@
 //! from the Linux kernel header file:
 //! [linux/can/error.h](https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/can/error.h)
 //!
+//! see also snprintf_can_error_frame() in https://github.com/linux-can/can-utils/blob/master/lib.c
+//! for the types of errors that can coexist in a single error frame:
+//! 1. prints the error class
+//! 2. prints informtion for each of CAN_ERR_LOSTARB, CAN_ERR_CRTL, CAN_ERR_PROT, CAN_ERR_CNT, if flags are set
+//! 3. prints error counts if they're nonzero even if CAN_ERR_CNT wasn't set
+//! 
+//! for example:
+//! cansend vcan0 200001FF#0011223344556677 (would be "3FF" for all flags, but a bug in 2023 and earlier cansend versions prevents printing if CAN_ERR_CNT is set)
+//! prints: (with candump -c -ta -H -d -e -x vcan0,0:0,#FFFFFFFF)
+//!  (0000000000.000000)  vcan0  TX - -  200001FF   [8]  00 11 22 33 44 55 66 77   ERRORFRAME
+//!  	tx-timeout
+//!  	lost-arbitration{at bit 0}
+//!  	controller-problem{rx-overflow,rx-error-passive}
+//!  	protocol-violation{{frame-format-error,bus-overload}{}}
+//!  	transceiver-status
+//!  	no-acknowledgement-on-tx
+//!  	bus-off
+//!  	bus-error
+//!  	restarted-after-bus-off
+//!  	error-counter-tx-rx{{102}{119}}
 
+use num_derive::FromPrimitive;    
+use num_traits::FromPrimitive;
 use crate::{CanErrorFrame, EmbeddedFrame, Frame};
 use std::{convert::TryFrom, error, fmt, io};
 use thiserror::Error;
@@ -51,13 +73,17 @@ use thiserror::Error;
 /// frames or from typical system I/O errors.
 #[derive(Error, Debug)]
 pub enum Error {
-    /// A CANbus error, usually from an error frmae
+    /// A CANbus error, usually from an error frame
     #[error(transparent)]
     Can(#[from] CanError),
     /// An I/O Error
     #[error(transparent)]
     Io(#[from] io::Error),
 }
+
+/*
+
+// todo - does this make sense?
 
 impl embedded_can::Error for Error {
     fn kind(&self) -> embedded_can::ErrorKind {
@@ -67,6 +93,7 @@ impl embedded_can::Error for Error {
         }
     }
 }
+*/
 
 impl From<CanErrorFrame> for Error {
     fn from(frame: CanErrorFrame) -> Self {
@@ -105,6 +132,30 @@ pub type IoErrorKind = io::ErrorKind;
 /// An I/O specific result
 pub type IoResult<T> = io::Result<T>;
 
+// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
+pub enum CanErrorFlags {
+    /// TX timeout (by netdevice driver)
+    TxTimeout = 0x00000001,
+    /// Lost arbitration / data[0]
+    LostArbitration = 0x00000002,
+    /// Controller problems / data[1]
+    ControllerProblems = 0x00000004,
+    /// Protocol violations / data[2..3]
+    ProtocolViolations = 0x00000008,
+    /// Transceiver status / data[4]
+    TransceiverStatus = 0x00000010,
+    /// Received no ACK on transmission
+    NoAck = 0x00000020,
+    /// Bus off
+    BusOff = 0x00000040,
+    /// Bus error (may flood!)
+    BusError = 0x00000080,
+    /// Controller restarted
+    Restarted = 0x00000100,
+    /// TX error counter / data[6] RX error counter / data[7]
+    TxErrorCounter = 0x00000200,
+}
+
 // ===== CanError ====
 
 /// A CAN bus error derived from an error frame.
@@ -121,76 +172,101 @@ pub type IoResult<T> = io::Result<T>;
 /// word of an error frame - a frame in which the CAN error flag
 /// (`CAN_ERR_FLAG`) is set. But there are additional types to handle any
 /// problems decoding the error frame.
-#[derive(Debug, Clone, Copy)]
-pub enum CanError {
+#[derive(Debug, Clone, Default)]
+pub struct CanError {
     /// TX timeout (by netdevice driver)
-    TransmitTimeout,
+    pub TransmitTimeout: bool,
     /// Arbitration was lost.
     /// Contains the bit number after which arbitration was lost or 0 if unspecified.
-    LostArbitration(u8),
+    pub LostArbitration: Option<LostArbitration>,
     /// Controller problem
-    ControllerProblem(ControllerProblem),
+    pub ControllerProblem: Option<ControllerProblem>,
     /// Protocol violation at the specified [`Location`].
-    ProtocolViolation {
-        /// The type of protocol violation
-        vtype: ViolationType,
-        /// The location (field or bit) of the violation
-        location: Location,
-    },
+    pub ProtocolViolation: Option<ProtocolViolation>,
     /// Transceiver Error.
-    TransceiverError,
+    pub TransceiverError: Option<TransceiverError>,
     /// No ACK received for current CAN frame.
-    NoAck,
+    pub NoAck: bool,
     /// Bus off (due to too many detected errors)
-    BusOff,
+    pub BusOff: bool,
     /// Bus error (due to too many detected errors)
-    BusError,
+    pub BusError: bool,
     /// The bus has been restarted
-    Restarted,
-    /// There was an error decoding the error frame
-    DecodingFailure(CanErrorDecodingFailure),
+    pub Restarted: bool,
+    /// error counters. either the bit is set with any byte[6-7] contents, or the bytes 6-7 are nonzero
+    pub ErrorCounts: Option<ErrorCounts>,    
+    /// list of errors decoding the error frame
+    pub DecodingFailure: Vec<CanErrorDecodingFailure>,
     /// Unknown, possibly invalid, error
-    Unknown(u32),
+    pub Unknown: Option<u32>,
 }
 
 impl error::Error for CanError {}
 
 impl fmt::Display for CanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use CanError::*;
-        match *self {
-            TransmitTimeout => write!(f, "transmission timeout"),
-            LostArbitration(n) => write!(f, "arbitration lost after {} bits", n),
-            ControllerProblem(e) => write!(f, "controller problem: {}", e),
-            ProtocolViolation { vtype, location } => {
-                write!(f, "protocol violation at {}: {}", location, vtype)
-            }
-            TransceiverError => write!(f, "transceiver error"),
-            NoAck => write!(f, "no ack"),
-            BusOff => write!(f, "bus off"),
-            BusError => write!(f, "bus error"),
-            Restarted => write!(f, "restarted"),
-            DecodingFailure(err) => write!(f, "decoding failure: {}", err),
-            Unknown(err) => write!(f, "unknown error ({})", err),
+        let mut parts = Vec::new();
+
+        if self.TransmitTimeout {
+            parts.push("transmission timeout".to_string());
         }
+        if let Some(ref lost_arbitration) = self.LostArbitration {
+            parts.push(format!("arbitration lost at bit {}", lost_arbitration.bit));
+        }
+        if let Some(ref controller_problem) = self.ControllerProblem {
+            parts.push(format!("controller problem: {}", controller_problem));
+        }
+        if let Some(ref protocol_violation) = self.ProtocolViolation {
+            parts.push(format!(
+                "protocol violation at {}: {}",
+                protocol_violation.location, protocol_violation.vtype
+            ));
+        }
+        if let Some(ref transceiver_error) = self.TransceiverError {
+            parts.push(format!("transceiver error: {}", transceiver_error));
+        }
+        if self.NoAck {
+            parts.push("no ack on tx".to_string());
+        }
+        if self.BusOff {
+            parts.push("bus off".to_string());
+        }
+        if self.BusError {
+            parts.push("bus error".to_string());
+        }
+        if self.Restarted {
+            parts.push("restarted after bus off".to_string());
+        }
+        if let Some(ref error_counts) = self.ErrorCounts {
+            parts.push(format!("error counts: tx {}, rx {}", error_counts.tx, error_counts.rx));
+        }
+        for err in &self.DecodingFailure {
+            parts.push(format!("decoding failure: {}", err));
+        }
+        if let Some(ref unknown) = self.Unknown {
+            parts.push(format!("unknown error ({})", unknown));
+        }
+
+        write!(f, "{}", parts.join("\n"))
     }
 }
 
 impl embedded_can::Error for CanError {
     fn kind(&self) -> embedded_can::ErrorKind {
-        match *self {
-            CanError::ControllerProblem(cp) => {
-                use ControllerProblem::*;
-                match cp {
-                    ReceiveBufferOverflow | TransmitBufferOverflow => {
-                        embedded_can::ErrorKind::Overrun
-                    }
-                    _ => embedded_can::ErrorKind::Other,
+        // a single error frame could translate multiple ways. just match the first way found
+        if let Some(controller_problem) = self.ControllerProblem {
+            use ControllerProblem::*;
+            match controller_problem {
+                ReceiveBufferOverflow | TransmitBufferOverflow => {
+                    return embedded_can::ErrorKind::Overrun
                 }
+                _ => return embedded_can::ErrorKind::Other,
             }
-            CanError::NoAck => embedded_can::ErrorKind::Acknowledge,
-            _ => embedded_can::ErrorKind::Other,
         }
+        if self.NoAck {
+            return embedded_can::ErrorKind::Acknowledge;
+        }
+        return embedded_can::ErrorKind::Other
     }
 }
 
@@ -199,38 +275,84 @@ impl From<CanErrorFrame> for CanError {
     fn from(frame: CanErrorFrame) -> Self {
         // Note that the CanErrorFrame is guaranteed to have the full 8-byte
         // data payload.
-        match frame.error_bits() {
-            0x0001 => CanError::TransmitTimeout,
-            0x0002 => CanError::LostArbitration(frame.data()[0]),
-            0x0004 => match ControllerProblem::try_from(frame.data()[1]) {
-                Ok(err) => CanError::ControllerProblem(err),
-                Err(err) => CanError::DecodingFailure(err),
-            },
-            0x0008 => {
-                match (
-                    ViolationType::try_from(frame.data()[2]),
-                    Location::try_from(frame.data()[3]),
-                ) {
-                    (Ok(vtype), Ok(location)) => CanError::ProtocolViolation { vtype, location },
-                    (Err(err), _) | (_, Err(err)) => CanError::DecodingFailure(err),
-                }
-            }
-            0x0010 => CanError::TransceiverError,
-            0x0020 => CanError::NoAck,
-            0x0040 => CanError::BusOff,
-            0x0080 => CanError::BusError,
-            0x0100 => CanError::Restarted,
-            err => CanError::Unknown(err),
+        let mut can_error: CanError = CanError::default();
+        if (frame.error_bits() & (CanErrorFlags::TxTimeout as u32)) != 0 {
+            can_error.TransmitTimeout = true;
         }
+        if (frame.error_bits() & (CanErrorFlags::LostArbitration as u32)) != 0 {
+            can_error.LostArbitration = Some(LostArbitration {
+                bit: frame.data()[0],
+            });
+        }
+        if (frame.error_bits() & (CanErrorFlags::ControllerProblems as u32)) != 0 {
+            match ControllerProblem::try_from(frame.data()[1]) {
+                Ok(err) => can_error.ControllerProblem = Some(err),
+                Err(err) => can_error.DecodingFailure.push(err),
+            }
+        }
+        if (frame.error_bits() & (CanErrorFlags::ProtocolViolations as u32)) != 0 {
+            match (
+                ViolationType::try_from(frame.data()[2]),
+                Location::try_from(frame.data()[3]),
+            ) {
+                (Ok(vtype), Ok(location)) => can_error.ProtocolViolation = Some(ProtocolViolation {
+                    vtype,
+                    location,
+                }),
+                (Err(err), _) | (_, Err(err)) => can_error.DecodingFailure.push(err),
+            }
+        }
+        if (frame.error_bits() & (CanErrorFlags::TransceiverStatus as u32)) != 0 {
+            match TransceiverError::try_from(frame.data()[4]) {
+                Ok(err) => can_error.TransceiverError = Some(err),
+                Err(err) => can_error.DecodingFailure.push(err),
+            }
+        }
+        if (frame.error_bits() & (CanErrorFlags::NoAck as u32)) != 0 {
+            can_error.NoAck = true;
+        }
+        if (frame.error_bits() & (CanErrorFlags::BusOff as u32)) != 0 {
+            can_error.BusOff = true;
+        }
+        if (frame.error_bits() & (CanErrorFlags::BusError as u32)) != 0 {
+            can_error.BusError = true;
+        }
+        if (frame.error_bits() & (CanErrorFlags::Restarted as u32)) != 0 {
+            can_error.Restarted = true;
+        }
+        if (frame.error_bits() & (CanErrorFlags::TxErrorCounter as u32)) != 0 {
+            can_error.ErrorCounts = Some(ErrorCounts {
+                tx: frame.data()[6],
+                rx: frame.data()[7],
+            });
+        } else if frame.data()[6] != 0 || frame.data()[7] != 0 {
+            can_error.ErrorCounts = Some(ErrorCounts {
+                tx: frame.data()[6],
+                rx: frame.data()[7],
+            });
+        }
+        can_error
     }
 }
+
+// ===== LostArbitration =====
+
+/// populated if CAN_ERR_LOSTARB is set
+#[derive(Debug, Clone, Copy)]
+pub struct LostArbitration {
+    /// The bit number after which arbitration was lost
+    pub bit: u8,
+}
+
+// todo impls
 
 // ===== ControllerProblem =====
 
 /// Error status of the CAN controller.
 ///
 /// This is derived from `data[1]` of an error frame
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+/// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, FromPrimitive)]
 #[repr(u8)]
 pub enum ControllerProblem {
     /// unspecified
@@ -252,7 +374,6 @@ pub enum ControllerProblem {
 }
 
 impl error::Error for ControllerProblem {}
-
 impl fmt::Display for ControllerProblem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ControllerProblem::*;
@@ -274,27 +395,30 @@ impl TryFrom<u8> for ControllerProblem {
     type Error = CanErrorDecodingFailure;
 
     fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
-        use ControllerProblem::*;
-        Ok(match val {
-            0x00 => Unspecified,
-            0x01 => ReceiveBufferOverflow,
-            0x02 => TransmitBufferOverflow,
-            0x04 => ReceiveErrorWarning,
-            0x08 => TransmitErrorWarning,
-            0x10 => ReceiveErrorPassive,
-            0x20 => TransmitErrorPassive,
-            0x40 => Active,
-            _ => return Err(CanErrorDecodingFailure::InvalidControllerProblem),
-        })
+        ControllerProblem::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidControllerProblem)
     }
 }
+
+// ===== ProtocolViolation =====
+
+/// populated if CAN_ERR_PROT is set
+#[derive(Debug, Clone, Copy)]
+pub struct ProtocolViolation {
+    /// The type of protocol violation
+    pub vtype: ViolationType,
+    /// The location (field or bit) of the violation
+    pub location: Location,
+}
+
+// todo impls
 
 // ===== ViolationType =====
 
 /// The type of protocol violation error.
 ///
 /// This is derived from `data[2]` of an error frame.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive)]
 #[repr(u8)]
 pub enum ViolationType {
     /// Unspecified Violation
@@ -336,24 +460,11 @@ impl fmt::Display for ViolationType {
         write!(f, "{}", msg)
     }
 }
-
 impl TryFrom<u8> for ViolationType {
     type Error = CanErrorDecodingFailure;
 
     fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
-        use ViolationType::*;
-        Ok(match val {
-            0x00 => Unspecified,
-            0x01 => SingleBitError,
-            0x02 => FrameFormatError,
-            0x04 => BitStuffingError,
-            0x08 => UnableToSendDominantBit,
-            0x10 => UnableToSendRecessiveBit,
-            0x20 => BusOverload,
-            0x40 => Active,
-            0x80 => TransmissionError,
-            _ => return Err(CanErrorDecodingFailure::InvalidViolationType),
-        })
+        ViolationType::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidViolationType)
     }
 }
 
@@ -363,7 +474,8 @@ impl TryFrom<u8> for ViolationType {
 /// or bit) at which an error occurred.
 ///
 /// This is derived from `data[3]` of an error frame.
-#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
+/// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
+#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, FromPrimitive)]
 #[repr(u8)]
 pub enum Location {
     /// Unspecified
@@ -436,34 +548,12 @@ impl fmt::Display for Location {
         write!(f, "{}", msg)
     }
 }
+
 impl TryFrom<u8> for Location {
     type Error = CanErrorDecodingFailure;
 
     fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
-        use Location::*;
-        Ok(match val {
-            0x00 => Unspecified,
-            0x03 => StartOfFrame,
-            0x02 => Id2821,
-            0x06 => Id2018,
-            0x04 => SubstituteRtr,
-            0x05 => IdentifierExtension,
-            0x07 => Id1713,
-            0x0F => Id1205,
-            0x0E => Id0400,
-            0x0C => Rtr,
-            0x0D => Reserved1,
-            0x09 => Reserved0,
-            0x0B => DataLengthCode,
-            0x0A => DataSection,
-            0x08 => CrcSequence,
-            0x18 => CrcDelimiter,
-            0x19 => AckSlot,
-            0x1B => AckDelimiter,
-            0x1A => EndOfFrame,
-            0x12 => Intermission,
-            _ => return Err(CanErrorDecodingFailure::InvalidLocation),
-        })
+        Location::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidLocation)
     }
 }
 
@@ -472,7 +562,8 @@ impl TryFrom<u8> for Location {
 /// The error status of the CAN transceiver.
 ///
 /// This is derived from `data[4]` of an error frame.
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+/// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, FromPrimitive)]
 #[repr(u8)]
 pub enum TransceiverError {
     /// Unsecified
@@ -501,20 +592,26 @@ impl TryFrom<u8> for TransceiverError {
     type Error = CanErrorDecodingFailure;
 
     fn try_from(val: u8) -> std::result::Result<Self, Self::Error> {
+        TransceiverError::from_u8(val).ok_or(CanErrorDecodingFailure::InvalidTransceiverError)
+    }
+}
+
+impl fmt::Display for TransceiverError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use TransceiverError::*;
-        Ok(match val {
-            0x00 => Unspecified,
-            0x04 => CanHighNoWire,
-            0x05 => CanHighShortToBat,
-            0x06 => CanHighShortToVcc,
-            0x07 => CanHighShortToGnd,
-            0x40 => CanLowNoWire,
-            0x50 => CanLowShortToBat,
-            0x60 => CanLowShortToVcc,
-            0x70 => CanLowShortToGnd,
-            0x80 => CanLowShortToCanHigh,
-            _ => return Err(CanErrorDecodingFailure::InvalidTransceiverError),
-        })
+        let msg = match *self {
+            Unspecified => "unspecified",
+            CanHighNoWire => "CAN High, no wire",
+            CanHighShortToBat => "CAN High, short to BAT",
+            CanHighShortToVcc => "CAN High, short to VCC",
+            CanHighShortToGnd => "CAN High, short to GND",
+            CanLowNoWire => "CAN Low, no wire",
+            CanLowShortToBat => "CAN Low, short to BAT",
+            CanLowShortToVcc => "CAN Low, short to VCC",
+            CanLowShortToGnd => "CAN Low, short to GND",
+            CanLowShortToCanHigh => "CAN Low, short to CAN High",
+        };
+        write!(f, "{}", msg)
     }
 }
 
@@ -578,6 +675,17 @@ impl fmt::Display for CanErrorDecodingFailure {
         write!(f, "{}", msg)
     }
 }
+
+/// populated if CAN_ERR_CNT is set *or* if either error count is nonzero
+#[derive(Debug, Clone, Copy)]
+pub struct ErrorCounts {
+    /// TX error counter data[6]
+    pub tx: u8,
+    /// RX error counter data[7]
+    pub rx: u8,
+}
+
+// todo impls
 
 // ===== ConstructionError =====
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -81,19 +81,14 @@ pub enum Error {
     Io(#[from] io::Error),
 }
 
-/*
-
-// todo - does this make sense?
-
 impl embedded_can::Error for Error {
     fn kind(&self) -> embedded_can::ErrorKind {
-        match *self {
+        match self {
             Error::Can(err) => err.kind(),
             _ => embedded_can::ErrorKind::Other,
         }
     }
 }
-*/
 
 impl From<CanErrorFrame> for Error {
     fn from(frame: CanErrorFrame) -> Self {
@@ -132,7 +127,13 @@ pub type IoErrorKind = io::ErrorKind;
 /// An I/O specific result
 pub type IoResult<T> = io::Result<T>;
 
-// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
+
+/// Error status of the CAN controller.
+///
+/// This is derived from `data[1]` of an error frame
+/// see original in https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/error.h
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, FromPrimitive)]
+#[repr(u32)]
 pub enum CanErrorFlags {
     /// TX timeout (by netdevice driver)
     TxTimeout = 0x00000001,
@@ -172,33 +173,33 @@ pub enum CanErrorFlags {
 /// word of an error frame - a frame in which the CAN error flag
 /// (`CAN_ERR_FLAG`) is set. But there are additional types to handle any
 /// problems decoding the error frame.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CanError {
     /// TX timeout (by netdevice driver)
-    pub TransmitTimeout: bool,
+    pub transmit_timeout: bool,
     /// Arbitration was lost.
     /// Contains the bit number after which arbitration was lost or 0 if unspecified.
-    pub LostArbitration: Option<LostArbitration>,
+    pub lost_arbitration: Option<LostArbitration>,
     /// Controller problem
-    pub ControllerProblem: Option<ControllerProblem>,
+    pub controller_problem: Option<ControllerProblem>,
     /// Protocol violation at the specified [`Location`].
-    pub ProtocolViolation: Option<ProtocolViolation>,
+    pub protocol_violation: Option<ProtocolViolation>,
     /// Transceiver Error.
-    pub TransceiverError: Option<TransceiverError>,
+    pub transceiver_error: Option<TransceiverError>,
     /// No ACK received for current CAN frame.
-    pub NoAck: bool,
+    pub no_ack: bool,
     /// Bus off (due to too many detected errors)
-    pub BusOff: bool,
+    pub bus_off: bool,
     /// Bus error (due to too many detected errors)
-    pub BusError: bool,
+    pub bus_error: bool,
     /// The bus has been restarted
-    pub Restarted: bool,
+    pub restarted: bool,
     /// error counters. either the bit is set with any byte[6-7] contents, or the bytes 6-7 are nonzero
-    pub ErrorCounts: Option<ErrorCounts>,    
+    pub error_counts: Option<ErrorCounts>,    
     /// list of errors decoding the error frame
-    pub DecodingFailure: Vec<CanErrorDecodingFailure>,
+    pub decoding_failure: Vec<CanErrorDecodingFailure>,
     /// Unknown, possibly invalid, error
-    pub Unknown: Option<u32>,
+    pub unknown: Option<u32>,
 }
 
 impl error::Error for CanError {}
@@ -207,43 +208,43 @@ impl fmt::Display for CanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut parts = Vec::new();
 
-        if self.TransmitTimeout {
+        if self.transmit_timeout {
             parts.push("transmission timeout".to_string());
         }
-        if let Some(ref lost_arbitration) = self.LostArbitration {
+        if let Some(ref lost_arbitration) = self.lost_arbitration {
             parts.push(format!("arbitration lost at bit {}", lost_arbitration.bit));
         }
-        if let Some(ref controller_problem) = self.ControllerProblem {
+        if let Some(ref controller_problem) = self.controller_problem {
             parts.push(format!("controller problem: {}", controller_problem));
         }
-        if let Some(ref protocol_violation) = self.ProtocolViolation {
+        if let Some(ref protocol_violation) = self.protocol_violation {
             parts.push(format!(
                 "protocol violation at {}: {}",
                 protocol_violation.location, protocol_violation.vtype
             ));
         }
-        if let Some(ref transceiver_error) = self.TransceiverError {
+        if let Some(ref transceiver_error) = self.transceiver_error {
             parts.push(format!("transceiver error: {}", transceiver_error));
         }
-        if self.NoAck {
+        if self.no_ack {
             parts.push("no ack on tx".to_string());
         }
-        if self.BusOff {
+        if self.bus_off {
             parts.push("bus off".to_string());
         }
-        if self.BusError {
+        if self.bus_error {
             parts.push("bus error".to_string());
         }
-        if self.Restarted {
+        if self.restarted {
             parts.push("restarted after bus off".to_string());
         }
-        if let Some(ref error_counts) = self.ErrorCounts {
+        if let Some(ref error_counts) = self.error_counts {
             parts.push(format!("error counts: tx {}, rx {}", error_counts.tx, error_counts.rx));
         }
-        for err in &self.DecodingFailure {
+        for err in &self.decoding_failure {
             parts.push(format!("decoding failure: {}", err));
         }
-        if let Some(ref unknown) = self.Unknown {
+        if let Some(ref unknown) = self.unknown {
             parts.push(format!("unknown error ({})", unknown));
         }
 
@@ -254,7 +255,7 @@ impl fmt::Display for CanError {
 impl embedded_can::Error for CanError {
     fn kind(&self) -> embedded_can::ErrorKind {
         // a single error frame could translate multiple ways. just match the first way found
-        if let Some(controller_problem) = self.ControllerProblem {
+        if let Some(controller_problem) = self.controller_problem {
             use ControllerProblem::*;
             match controller_problem {
                 ReceiveBufferOverflow | TransmitBufferOverflow => {
@@ -263,7 +264,7 @@ impl embedded_can::Error for CanError {
                 _ => return embedded_can::ErrorKind::Other,
             }
         }
-        if self.NoAck {
+        if self.no_ack {
             return embedded_can::ErrorKind::Acknowledge;
         }
         return embedded_can::ErrorKind::Other
@@ -277,17 +278,17 @@ impl From<CanErrorFrame> for CanError {
         // data payload.
         let mut can_error: CanError = CanError::default();
         if (frame.error_bits() & (CanErrorFlags::TxTimeout as u32)) != 0 {
-            can_error.TransmitTimeout = true;
+            can_error.transmit_timeout = true;
         }
         if (frame.error_bits() & (CanErrorFlags::LostArbitration as u32)) != 0 {
-            can_error.LostArbitration = Some(LostArbitration {
+            can_error.lost_arbitration = Some(LostArbitration {
                 bit: frame.data()[0],
             });
         }
         if (frame.error_bits() & (CanErrorFlags::ControllerProblems as u32)) != 0 {
             match ControllerProblem::try_from(frame.data()[1]) {
-                Ok(err) => can_error.ControllerProblem = Some(err),
-                Err(err) => can_error.DecodingFailure.push(err),
+                Ok(err) => can_error.controller_problem = Some(err),
+                Err(err) => can_error.decoding_failure.push(err),
             }
         }
         if (frame.error_bits() & (CanErrorFlags::ProtocolViolations as u32)) != 0 {
@@ -295,38 +296,38 @@ impl From<CanErrorFrame> for CanError {
                 ViolationType::try_from(frame.data()[2]),
                 Location::try_from(frame.data()[3]),
             ) {
-                (Ok(vtype), Ok(location)) => can_error.ProtocolViolation = Some(ProtocolViolation {
+                (Ok(vtype), Ok(location)) => can_error.protocol_violation = Some(ProtocolViolation {
                     vtype,
                     location,
                 }),
-                (Err(err), _) | (_, Err(err)) => can_error.DecodingFailure.push(err),
+                (Err(err), _) | (_, Err(err)) => can_error.decoding_failure.push(err),
             }
         }
         if (frame.error_bits() & (CanErrorFlags::TransceiverStatus as u32)) != 0 {
             match TransceiverError::try_from(frame.data()[4]) {
-                Ok(err) => can_error.TransceiverError = Some(err),
-                Err(err) => can_error.DecodingFailure.push(err),
+                Ok(err) => can_error.transceiver_error = Some(err),
+                Err(err) => can_error.decoding_failure.push(err),
             }
         }
         if (frame.error_bits() & (CanErrorFlags::NoAck as u32)) != 0 {
-            can_error.NoAck = true;
+            can_error.no_ack = true;
         }
         if (frame.error_bits() & (CanErrorFlags::BusOff as u32)) != 0 {
-            can_error.BusOff = true;
+            can_error.bus_off = true;
         }
         if (frame.error_bits() & (CanErrorFlags::BusError as u32)) != 0 {
-            can_error.BusError = true;
+            can_error.bus_error = true;
         }
         if (frame.error_bits() & (CanErrorFlags::Restarted as u32)) != 0 {
-            can_error.Restarted = true;
+            can_error.restarted = true;
         }
         if (frame.error_bits() & (CanErrorFlags::TxErrorCounter as u32)) != 0 {
-            can_error.ErrorCounts = Some(ErrorCounts {
+            can_error.error_counts = Some(ErrorCounts {
                 tx: frame.data()[6],
                 rx: frame.data()[7],
             });
         } else if frame.data()[6] != 0 || frame.data()[7] != 0 {
-            can_error.ErrorCounts = Some(ErrorCounts {
+            can_error.error_counts = Some(ErrorCounts {
                 tx: frame.data()[6],
                 rx: frame.data()[7],
             });
@@ -338,7 +339,7 @@ impl From<CanErrorFrame> for CanError {
 // ===== LostArbitration =====
 
 /// populated if CAN_ERR_LOSTARB is set
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LostArbitration {
     /// The bit number after which arbitration was lost
     pub bit: u8,
@@ -402,7 +403,7 @@ impl TryFrom<u8> for ControllerProblem {
 // ===== ProtocolViolation =====
 
 /// populated if CAN_ERR_PROT is set
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ProtocolViolation {
     /// The type of protocol violation
     pub vtype: ViolationType,
@@ -637,7 +638,7 @@ impl<T: Frame> ControllerSpecificErrorInformation for T {
 // ===== CanErrorDecodingFailure =====
 
 /// Error decoding a CanError from a CanErrorFrame.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CanErrorDecodingFailure {
     /// The supplied CANFrame did not have the error bit set.
     NotAnError,
@@ -677,7 +678,7 @@ impl fmt::Display for CanErrorDecodingFailure {
 }
 
 /// populated if CAN_ERR_CNT is set *or* if either error count is nonzero
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ErrorCounts {
     /// TX error counter data[6]
     pub tx: u8,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1212,14 +1212,16 @@ impl From<CanError> for CanErrorFrame {
             can_id |= CanErrorFlags::LostArbitration as u32;
             data[0] = lost_arbitration.bit;
         }
-        if let Some(controller_problem) = err.controller_problem {
+        for controller_problem in err.controller_problems {
             can_id |= CanErrorFlags::ControllerProblems as u32;
-            data[1] = controller_problem as u8;
+            data[1] |= controller_problem as u8;
         }
-        if let Some(protocol_violation) = err.protocol_violation {
+        for protocol_violation in err.protocol_violations {
             can_id |= CanErrorFlags::ProtocolViolations as u32;
-            data[2] = protocol_violation.vtype as u8;
-            data[3] = protocol_violation.location as u8;
+            data[2] = protocol_violation as u8;
+        }
+        if let Some(location) = err.location {
+            data[3] = location as u8;
         }
         if let Some(transceiver_error) = err.transceiver_error {
             can_id |= CanErrorFlags::TransceiverStatus as u32;
@@ -1743,10 +1745,8 @@ mod tests {
         assert_eq!(err_in, err_out);
 
         let err_in = CanError {
-            protocol_violation: Some(errors::ProtocolViolation {
-                vtype: errors::ViolationType::BitStuffingError,
-                location: errors::Location::Id0400,
-            }),
+            protocol_violations: vec![errors::ViolationType::BitStuffingError],
+            location: Some(errors::Location::Id0400),
             ..Default::default()
         };
         let frame = CanErrorFrame::from(err_in.clone());

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1036,6 +1036,15 @@ impl AsRef<can_frame> for CanRemoteFrame {
 #[derive(Clone, Copy)]
 pub struct CanErrorFrame(can_frame);
 
+impl PartialEq for CanErrorFrame {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.can_id == other.0.can_id
+            && self.0.can_dlc == other.0.can_dlc
+            && self.0.len8_dlc == other.0.len8_dlc
+            && self.0.data[..] == other.0.data[..]
+    }
+}
+
 impl CanErrorFrame {
     /// Creates a CAN error frame from raw parts.
     ///
@@ -1196,36 +1205,36 @@ impl From<CanError> for CanErrorFrame {
         let mut data = [0u8; CAN_MAX_DLEN];
         let mut can_id: canid_t = CAN_ERR_FLAG;
 
-        if err.TransmitTimeout {
+        if err.transmit_timeout {
             can_id |= CanErrorFlags::TxTimeout as u32;
         }
-        if let Some(lost_arbitration) = err.LostArbitration {
+        if let Some(lost_arbitration) = err.lost_arbitration {
             can_id |= CanErrorFlags::LostArbitration as u32;
             data[0] = lost_arbitration.bit;
         }
-        if let Some(controller_problem) = err.ControllerProblem {
+        if let Some(controller_problem) = err.controller_problem {
             can_id |= CanErrorFlags::ControllerProblems as u32;
             data[1] = controller_problem as u8;
         }
-        if let Some(protocol_violation) = err.ProtocolViolation {
+        if let Some(protocol_violation) = err.protocol_violation {
             can_id |= CanErrorFlags::ProtocolViolations as u32;
             data[2] = protocol_violation.vtype as u8;
             data[3] = protocol_violation.location as u8;
         }
-        if let Some(transceiver_error) = err.TransceiverError {
+        if let Some(transceiver_error) = err.transceiver_error {
             can_id |= CanErrorFlags::TransceiverStatus as u32;
             data[4] = transceiver_error as u8;
         }
-        if err.NoAck {
+        if err.no_ack {
             can_id |= CanErrorFlags::NoAck as u32;
         }
-        if err.BusOff {
+        if err.bus_off {
             can_id |= CanErrorFlags::BusOff as u32;
         }
-        if err.BusError {
+        if err.bus_error {
             can_id |= CanErrorFlags::BusError as u32;
         }
-        if err.Restarted {
+        if err.restarted {
             can_id |= CanErrorFlags::Restarted as u32;
         }
         // ignore parsing errors for CanErrorFrame -> CanError
@@ -1699,7 +1708,7 @@ mod tests {
         frame.can_id = CAN_ERR_FLAG | 0x0010;
 
         let err = CanError::from(CanErrorFrame(frame));
-        assert!(matches!(err.TransceiverError, Some(TransceiverError::Unspecified)));
+        assert!(matches!(err.transceiver_error, Some(TransceiverError::Unspecified)));
 
         let id = StandardId::new(0x0010).unwrap();
         let frame = CanErrorFrame::new(id, &[]).unwrap();
@@ -1708,7 +1717,7 @@ mod tests {
         assert!(frame.is_error_frame());
 
         let err = CanError::from(frame);
-        assert!(matches!(err.TransceiverError, Some(TransceiverError::Unspecified)));
+        assert!(matches!(err.transceiver_error, Some(TransceiverError::Unspecified)));
 
         let id = ExtendedId::new(0x0020).unwrap();
         let frame = CanErrorFrame::new(id, &[]).unwrap();
@@ -1717,39 +1726,36 @@ mod tests {
         assert!(frame.is_error_frame());
 
         let err = CanError::from(frame);
-        assert!(err.NoAck);
+        assert!(err.no_ack);
 
         // From CanErrors
 
-        let err_in = CanErrorFrame::from(CanError {
-            TransmitTimeout: true,
+        let err_in = CanError {
+            transmit_timeout: true,
             ..Default::default()
-        });
-        let frame = CanErrorFrame::from(CanError {
-            TransmitTimeout: true,
-            ..Default::default()
-        });
+        };
+        let frame = CanErrorFrame::from(err_in.clone());
         assert!(!frame.is_data_frame());
         assert!(!frame.is_remote_frame());
         assert!(frame.is_error_frame());
 
         let err_out = frame.into_error();
-        assert!(matches!(err_in, err_out));
+        assert!(err_in == err_out);
 
-        let err_in = CanErrorFrame::from(CanError {
-            ProtocolViolation: Some(errors::ProtocolViolation {
+        let err_in = CanError {
+            protocol_violation: Some(errors::ProtocolViolation {
                 vtype: errors::ViolationType::BitStuffingError,
                 location: errors::Location::Id0400,
             }),
             ..Default::default()
-        });
-        let frame = CanErrorFrame::from(err);
+        };
+        let frame = CanErrorFrame::from(err_in.clone());
         assert!(!frame.is_data_frame());
         assert!(!frame.is_remote_frame());
         assert!(frame.is_error_frame());
 
         let err_out = frame.into_error();
-        assert!(matches!(err_in, err_out));
+        assert!(err_in == err_out);
     }
 
     #[test]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1740,7 +1740,7 @@ mod tests {
         assert!(frame.is_error_frame());
 
         let err_out = frame.into_error();
-        assert!(err_in == err_out);
+        assert_eq!(err_in, err_out);
 
         let err_in = CanError {
             protocol_violation: Some(errors::ProtocolViolation {
@@ -1755,7 +1755,7 @@ mod tests {
         assert!(frame.is_error_frame());
 
         let err_out = frame.into_error();
-        assert!(err_in == err_out);
+        assert_eq!(err_in, err_out);
     }
 
     #[test]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -30,7 +30,7 @@
 //!   [Error](https://doc.rust-lang.org/std/error/trait.Error.html) types.
 //!
 
-use crate::{id::CanId, CanError, ConstructionError};
+use crate::{errors::CanErrorFlags, id::CanId, CanError, ConstructionError};
 use embedded_can::{ExtendedId, Frame as EmbeddedFrame, Id, StandardId};
 use itertools::Itertools;
 use libc::{can_frame, canfd_frame, canid_t};
@@ -1192,33 +1192,45 @@ impl TryFrom<can_frame> for CanErrorFrame {
 
 impl From<CanError> for CanErrorFrame {
     fn from(err: CanError) -> Self {
-        use CanError::*;
 
         let mut data = [0u8; CAN_MAX_DLEN];
-        let id: canid_t = match err {
-            TransmitTimeout => 0x0001,
-            LostArbitration(bit) => {
-                data[0] = bit;
-                0x0002
-            }
-            ControllerProblem(prob) => {
-                data[1] = prob as u8;
-                0x0004
-            }
-            ProtocolViolation { vtype, location } => {
-                data[2] = vtype as u8;
-                data[3] = location as u8;
-                0x0008
-            }
-            TransceiverError => 0x0010,
-            NoAck => 0x0020,
-            BusOff => 0x0040,
-            BusError => 0x0080,
-            Restarted => 0x0100,
-            DecodingFailure(_failure) => 0,
-            Unknown(e) => e,
-        };
-        Self::new_error(id, &data).unwrap()
+        let mut can_id: canid_t = CAN_ERR_FLAG;
+
+        if err.TransmitTimeout {
+            can_id |= CanErrorFlags::TxTimeout as u32;
+        }
+        if let Some(lost_arbitration) = err.LostArbitration {
+            can_id |= CanErrorFlags::LostArbitration as u32;
+            data[0] = lost_arbitration.bit;
+        }
+        if let Some(controller_problem) = err.ControllerProblem {
+            can_id |= CanErrorFlags::ControllerProblems as u32;
+            data[1] = controller_problem as u8;
+        }
+        if let Some(protocol_violation) = err.ProtocolViolation {
+            can_id |= CanErrorFlags::ProtocolViolations as u32;
+            data[2] = protocol_violation.vtype as u8;
+            data[3] = protocol_violation.location as u8;
+        }
+        if let Some(transceiver_error) = err.TransceiverError {
+            can_id |= CanErrorFlags::TransceiverStatus as u32;
+            data[4] = transceiver_error as u8;
+        }
+        if err.NoAck {
+            can_id |= CanErrorFlags::NoAck as u32;
+        }
+        if err.BusOff {
+            can_id |= CanErrorFlags::BusOff as u32;
+        }
+        if err.BusError {
+            can_id |= CanErrorFlags::BusError as u32;
+        }
+        if err.Restarted {
+            can_id |= CanErrorFlags::Restarted as u32;
+        }
+        // ignore parsing errors for CanErrorFrame -> CanError
+
+        Self::new_error(can_id, &data).unwrap()
     }
 }
 
@@ -1489,7 +1501,7 @@ impl AsRef<canfd_frame> for CanFdFrame {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::errors;
+    use crate::errors::{self, TransceiverError};
 
     const STD_ID: Id = Id::Standard(StandardId::MAX);
     const EXT_ID: Id = Id::Extended(ExtendedId::MAX);
@@ -1687,7 +1699,7 @@ mod tests {
         frame.can_id = CAN_ERR_FLAG | 0x0010;
 
         let err = CanError::from(CanErrorFrame(frame));
-        assert!(matches!(err, CanError::TransceiverError));
+        assert!(matches!(err.TransceiverError, Some(TransceiverError::Unspecified)));
 
         let id = StandardId::new(0x0010).unwrap();
         let frame = CanErrorFrame::new(id, &[]).unwrap();
@@ -1696,7 +1708,7 @@ mod tests {
         assert!(frame.is_error_frame());
 
         let err = CanError::from(frame);
-        assert!(matches!(err, CanError::TransceiverError));
+        assert!(matches!(err.TransceiverError, Some(TransceiverError::Unspecified)));
 
         let id = ExtendedId::new(0x0020).unwrap();
         let frame = CanErrorFrame::new(id, &[]).unwrap();
@@ -1705,34 +1717,39 @@ mod tests {
         assert!(frame.is_error_frame());
 
         let err = CanError::from(frame);
-        assert!(matches!(err, CanError::NoAck));
+        assert!(err.NoAck);
 
         // From CanErrors
 
-        let frame = CanErrorFrame::from(CanError::TransmitTimeout);
+        let err_in = CanErrorFrame::from(CanError {
+            TransmitTimeout: true,
+            ..Default::default()
+        });
+        let frame = CanErrorFrame::from(CanError {
+            TransmitTimeout: true,
+            ..Default::default()
+        });
         assert!(!frame.is_data_frame());
         assert!(!frame.is_remote_frame());
         assert!(frame.is_error_frame());
 
-        let err = frame.into_error();
-        assert!(matches!(err, CanError::TransmitTimeout));
+        let err_out = frame.into_error();
+        assert!(matches!(err_in, err_out));
 
-        let err = CanError::ProtocolViolation {
-            vtype: errors::ViolationType::BitStuffingError,
-            location: errors::Location::Id0400,
-        };
+        let err_in = CanErrorFrame::from(CanError {
+            ProtocolViolation: Some(errors::ProtocolViolation {
+                vtype: errors::ViolationType::BitStuffingError,
+                location: errors::Location::Id0400,
+            }),
+            ..Default::default()
+        });
         let frame = CanErrorFrame::from(err);
         assert!(!frame.is_data_frame());
         assert!(!frame.is_remote_frame());
         assert!(frame.is_error_frame());
 
-        match frame.into_error() {
-            CanError::ProtocolViolation { vtype, location } => {
-                assert_eq!(vtype, errors::ViolationType::BitStuffingError);
-                assert_eq!(location, errors::Location::Id0400);
-            }
-            _ => assert!(false),
-        }
+        let err_out = frame.into_error();
+        assert!(matches!(err_in, err_out));
     }
 
     #[test]


### PR DESCRIPTION
skip to test_error_printing() to see the problem - I noticed that the error parsing in socketcan-rs was simpler than the parsing in the socketcan C library that you get see you run candump

changes:
- updated CanError to allow multiples of things that are bit flags and match the decoding in socketcan's C library
- changed error printing to be more similar to the C library
- added a couple dependencies to help reduce duplicated copies of enums

I didn't give much thought to performance, my application doesn't need it, but I can make performance changes if you see any problems

I'm using this branch in my application now and it's working fine