### PR TITLE
Show members for all features in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ Linux SocketCAN library. Send and receive CAN frames via CANbus on Linux.
 
 # Features:
 #
-# "netlink" (default) - Whether to include CAN interface configuration 
+# "netlink" (default) - Whether to include CAN interface configuration
 #       capabilities based on netlink kernel communications
-# "dump" (default) - Whether to include 'candump' log file parsing 
+# "dump" (default) - Whether to include 'candump' log file parsing
 #	capabilities.
 # "enumerate" - Ability to enumerate the available CAN network interfaces
 #
@@ -82,6 +82,11 @@ async-std = { version = "1.12", features = ["attributes"]}
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util"] }
 futures = "0.3"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
+
 
 [[bin]]
 name = "rcan"
@@ -134,4 +139,3 @@ required-features = ["async-std"]
 [[example]]
 name = "async_std_print_frames"
 required-features = ["async-std"]
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@
 //!   Requires superuser privileges to run/pass.
 //!
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // clippy: do not warn about things like "SocketCAN" inside the docs
 #![allow(clippy::doc_markdown)]
 // Some lints


### PR DESCRIPTION
The docs.rs documentation is currently not very useful, as it doesn't show anything that is conditionally compiled by enabling non-default features. With this PR all members are always shown, with an optional note next to them indicating if they are feature-gated.

Test this change by generating the docs locally with the following cargo command
```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```

Some of the dependencies' documentation is borked because of rust-lang/rust#43781 which interferes with local documentation builds. I don't know docs.rs handles this; it's possible these dependencies will have to be bumped.