### PR TITLE
Update itertools dependency to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ embedded-can = "0.4"
 nb = "1"
 log = "0.4"
 hex = "0.4"
-itertools = "0.13"
+itertools = "0.14"
 libc = "0.2"
 nix = { version="0.29", features = ["poll", "process", "net"] }
 bitflags = "2.6"


### PR DESCRIPTION
Update to the latest `itertools` minor version.

This update does not affect any functions we use. Therefore bumping it in `Cargo.toml` should be sufficient.

Link: https://github.com/rust-itertools/itertools/blob/master/CHANGELOG.md#0140
Link: https://docs.rs/itertools/0.14.0/itertools/index.html