### PR TITLE
Update nix dependency to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.4"
 hex = "0.4"
 itertools = "0.13"
 libc = "0.2"
-nix = { version="0.29", features = ["poll", "process", "net"] }
+nix = { version="0.30", features = ["poll", "process", "net"] }
 bitflags = "2.6"
 thiserror = "2"
 socket2 = { version = "0.5", features = ["all"] }


### PR DESCRIPTION
Update to the latest `nix` minor version.

This update does not affect any functions we use. Therefore bumping it in `Cargo.toml` should be sufficient.

Link: https://github.com/nix-rust/nix/blob/master/CHANGELOG.md#0300---2025-04-29
Link: https://docs.rs/nix/0.30.1/nix/index.html