### PR TITLE
Update clap dependency to 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ nix = { version="0.29", features = ["poll", "process", "net"] }
 bitflags = "2.6"
 thiserror = "2"
 socket2 = { version = "0.5", features = ["all"] }
-clap = { version = "3.2", optional = true }
+clap = { version = "4", optional = true }
 anyhow = { version = "1", optional = true }
 tokio = { version = "1", features = ["net"], optional = true }
 mio = { version = "1", features = ["os-ext"], optional = true }
@@ -71,7 +71,7 @@ neli = { version = "0.6", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
-clap = "3.2"
+clap = "4"
 ctrlc = "3.2.2"
 nb = "1.0"
 # TODO: Is it possible to only include these for async builds?


### PR DESCRIPTION
Update to the latest `clap` major version.

Breaking changes of clap v4.0 seem to not affect us. Therefore bumping it in `Cargo.toml` should be sufficient.

Link: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28