### PR TITLE
Disable async-io/async-std/smol features for docs.rs 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 #
 # It does the following:
 # - Format check of the sources using nightly
-# - Build check using the current stable compiler and the MSRV version.
+# - Build check using the current stable, nightly and MSRV compiler versions.
 #   - Check library, utils, examples, and tests
 # - Clippy check using the MSRV compiler
 #
@@ -39,12 +39,16 @@ jobs:
         rust:
           - stable
           - 1.75.0
+          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libudev-dev
 
       - name: Resolve dependencies for MSRV
         run: |
@@ -59,10 +63,18 @@ jobs:
         run: cargo +${{ matrix.rust }} check --all-targets --features=tokio,utils
 
       - name: smol build check
+        # Building with one of the `async-io`/`async-std`/`smol` features enabled
+        # fails with recent nightly compilers: https://github.com/socketcan-rs/socketcan-rs/issues/98
+        #
+        # TODO: Remove this check once the issue is fixed in 4.0.
+        if: matrix.rust != 'nightly'
         run: cargo +${{ matrix.rust }} check --all-targets --features=smol,utils
 
       - name: Doc generation
-        run: cargo +${{ matrix.rust }} doc --no-deps
+        # Same issue as above.
+        #
+        # TODO: Remove this check once the issue is fixed in 4.0.
+        run: cargo +${{ matrix.rust }} doc --no-deps ${{ case(matrix.rust == 'nightly', '--features netlink,dump,enumerate,utils,tokio', '--all-features') }}
 
       - name: Run tests
         run: cargo +${{ matrix.rust }} test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,12 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-ut
 futures = "0.3"
 
 [package.metadata.docs.rs]
-all-features = true
+# Building the documentation with one of the `async-io`/`async-std`/`smol` features enabled
+# fails with recent nightly compilers, like the one used by docs.rs: https://github.com/socketcan-rs/socketcan-rs/issues/102
+# This enables all features except for those listed above.
+#
+# TODO: Switch back to `all-features = true` once that is resolved in 4.0.
+features = ["netlink", "dump", "enumerate", "utils", "tokio"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 


### PR DESCRIPTION
This disables some features that won't compile on nightly for docs.rs builds. I also took the liberty of adding a nightly compiler build to the CI workflow, so that these kinds of issues can be caught earlier in the future.

Fixes #102