### PR TITLE
Cargo: bump nix dependency from 0.29 to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ log = "0.4"
 hex = "0.4"
 itertools = "0.13"
 libc = { version = "0.2", features = ["extra_traits"] }
-nix = { version="0.29", features = ["poll", "process", "net"] }
+nix = { version="0.31", features = ["poll", "process", "net"] }
 bitflags = "2.6"
 thiserror = "2"
 socket2 = { version = "0.5", features = ["all"] }


### PR DESCRIPTION
Before this update the socketcan-rs crate indirectly required two different nix versions. 0.29 as a direct dependency and 0.31 as a dependency of the ctrlc crate (which is a dev-dependency).

Bumping the version should be fine as the MSRV of nix 0.31 is 1.69 and therefore blow ours.